### PR TITLE
[Fix] #3 - asset catalog 에러 해결

### DIFF
--- a/Walkie-iOS/Project.swift
+++ b/Walkie-iOS/Project.swift
@@ -26,7 +26,6 @@ let project = Project(
             dependencies: [],
             settings: .settings(
                 base: [
-                    "ENABLE_ASSET_SYMBOL_EXTENSIONS": "YES",
                     "ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "YES"
                 ]
             )


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
`Project.swift` 내 빌드 세팅 속성 중
`"ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "YES"`로 #2 의 에러를 해결하였습니다.

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->
`"ENABLE_ASSET_SYMBOL_EXTENSIONS": "YES"`는 해당 에러와 상관 없는 것 같아서(디폴트 값이 `"YES"`) 삭제 후 빌드 성공 확인하였습니다.

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

📟 **관련 이슈**
- Resolved: #3 
