### PR TITLE
[Feat] #10 - Common - Text Fields Text area 구현

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TextFields/TextAreaView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TextFields/TextAreaView.swift
@@ -1,0 +1,72 @@
+//
+//  TextAreaView.swift
+//  Walkie-iOS
+//
+//  Created by 황채웅 on 2/11/25.
+//
+
+import SwiftUI
+
+struct TextAreaView: View {
+    private var limitation: Int
+    private var placeholderText: String
+    
+    @State private var input: String = ""
+    @State private var inputState: InputState = .default
+    
+    init(limitation: Int, placeholderText: String) {
+        self.limitation = limitation
+        self.placeholderText = placeholderText
+    }
+    
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            TextEditor(text: $input)
+                .font(.B2)
+                .foregroundStyle(.gray700)
+                .background(.gray100)
+                .autocorrectionDisabled(true)
+                .scrollContentBackground(.hidden)
+                .multilineTextAlignment(.leading)
+                .contentMargins(.horizontal, 12)
+                .contentMargins(.top, 6)
+                .contentMargins(.bottom, 30)
+                .frame(height: 233)
+                .onChange(of: input) { oldValue, newValue in
+                    self.inputState = newValue.isEmpty ? .default : .focus
+                    if newValue.count > limitation {
+                        inputState = .error
+                        input = oldValue
+                    }
+                }
+                .frame(height: 233)
+                .cornerRadius(20)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(inputState.barColor, lineWidth: 1)
+                )
+            
+            if input.isEmpty {
+                Text(placeholderText)
+                    .font(.B2)
+                    .foregroundStyle(.gray400)
+                    .padding(.leading, 18)
+                    .padding(.top, 15)
+                    .allowsHitTesting(false)
+            }
+            
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Text("\(input.count)/\(limitation)")
+                        .font(.B2)
+                        .foregroundStyle(.gray400)
+                        .padding(.bottom, 16)
+                        .padding(.trailing, 16)
+                }
+            }
+        }
+        .frame(height: 233)
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 최대한 SwiftUI를 사용하려고 `TextEditor` 사용하여 구현하였습니다.
  - UIKit의 `TextView`도 사실 구현이 깔끔한 편은 아니라 그냥 최대한 그대로 사용했습니다..
  - 아무튼 별로네요
- 아래와 같이 사용하면 됩니다
  ```swift
  TextAreaView(limitation: 40, placeholderText: "입력해주세요")
  ```

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->
- `TextEditor`에 자체 플레이스홀더 기능이 없고, 커서 크기 및 위치가 인풋이 `nil`일 때 기본 시스템 폰트대로 적용되는 고질병이 있어서, 레이아웃은 거의 눈대중과 하드코딩으로 맞추었습니다.
- 글자 수 초과 입력 시도 시 입력 제한되도록 하였습니다.(디자이너님과 상의 완료)

📸 **스크린샷**
|기능|초기 상태|터치 시|입력 시|
|:--:|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/8e108160-423b-4437-9b5a-933cd85f19b0" width ="250">|<img src = "https://github.com/user-attachments/assets/e966691d-b506-4ed6-8f3c-e9e6b5314565" width ="250">|<img src = "https://github.com/user-attachments/assets/a99c80d8-8ec2-45eb-84c6-799a0c70eb81" width ="250">|


📟 **관련 이슈**
- Resolved: #10 
