### PR TITLE
[Feat] #44 - Keychain 세팅 및 UserManager 구현

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/TokenKeychainManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/TokenKeychainManager.swift
@@ -1,0 +1,128 @@
+//
+//  TokenKeychainManager.swift
+//  Walkie-iOS
+//
+//  Created by ahra on 3/5/25.
+//
+
+import Foundation
+import Security
+
+enum KeychainError: Error {
+    case failConvertData
+    case itemNotExist
+    case invalidData
+    case unknownError(OSStatus)
+}
+
+enum KeychainKeys {
+    static let accessToken = "accessToken"
+    static let refreshToken = "refreshToken"
+}
+
+final class TokenKeychainManager {
+    
+    static let shared = TokenKeychainManager()
+    
+    private init() {}
+    
+    // MARK: - save data
+    
+    func save(key: String, value: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.failConvertData
+        }
+        
+        try? delete(key: key)
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status != errSecSuccess {
+            throw KeychainError.unknownError(status)
+        }
+    }
+    
+    // MARK: - load data
+    
+    func load(key: String) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        
+        if status == errSecItemNotFound {
+            throw KeychainError.itemNotExist
+        } else if status != errSecSuccess {
+            throw KeychainError.unknownError(status)
+        }
+        
+        guard let data = dataTypeRef as? Data, let value = String(data: data, encoding: .utf8) else {
+            throw KeychainError.invalidData
+        }
+        return value
+    }
+    
+    // MARK: - delete data
+    
+    func delete(key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw KeychainError.unknownError(status)
+        }
+    }
+    
+    // MARK: - accessToken
+    
+    func saveAccessToken(_ token: String) throws {
+        try save(key: KeychainKeys.accessToken, value: token)
+    }
+    
+    func getAccessToken() throws -> String? {
+        return try load(key: KeychainKeys.accessToken)
+    }
+    
+    // MARK: - refreshToken
+    
+    func saveRefreshToken(_ token: String) throws {
+        try save(key: KeychainKeys.refreshToken, value: token)
+    }
+    
+    func getRefreshToken() throws -> String? {
+        return try load(key: KeychainKeys.refreshToken)
+    }
+    
+    // MARK: - delete all tokens
+    
+    func removeTokens() throws {
+        try delete(key: KeychainKeys.accessToken)
+        try delete(key: KeychainKeys.refreshToken)
+    }
+    
+    // MARK: - check has token
+    
+    func hasToken() -> Bool {
+        do {
+            if let accessToken = try getAccessToken(), !accessToken.isEmpty {
+                return true
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserDefaultWrapper.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserDefaultWrapper.swift
@@ -1,0 +1,30 @@
+//
+//  UserDefaultWrapper.swift
+//  Walkie-iOS
+//
+//  Created by ahra on 3/5/25.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefaultWrapper<T> {
+    
+    var wrappedValue: T? {
+        get {
+            return UserDefaults.standard.object(forKey: self.key) as? T
+        }
+        
+        set {
+            if newValue == nil {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else { UserDefaults.standard.setValue(newValue, forKey: key) }
+        }
+    }
+    
+    private let key: String
+    
+    init(key: String) {
+        self.key = key
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserDefaultsWrapper.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserDefaultsWrapper.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @propertyWrapper
-struct UserDefaultWrapper<T> {
+struct UserDefaultsWrapper<T> {
     
     var wrappedValue: T? {
         get {

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
@@ -1,0 +1,32 @@
+//
+//  UserManager.swift
+//  Walkie-iOS
+//
+//  Created by ahra on 3/5/25.
+//
+
+import SwiftUI
+
+final class UserManager {
+    
+    static let shared = UserManager()
+    
+    // MARK: - Properties
+    
+    @UserDefaultWrapper<String>(key: "userNickname") private(set) var userNickname
+    
+    private init() {}
+}
+
+extension UserManager {
+    
+    var hasUserNickname: Bool { return self.userNickname != "" }
+    var getUserNickname: String { return self.userNickname ?? ""}
+}
+
+extension UserManager {
+    
+    func setUserNickname(_ nickname: String) {
+        self.userNickname = nickname
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
@@ -14,17 +14,24 @@ final class UserManager {
     // MARK: - Properties
     
     @UserDefaultWrapper<String>(key: "userNickname") private(set) var userNickname
+    @UserDefaultWrapper<Bool>(key: "tapStart") private(set) var tapStart
     
     private init() {}
 }
 
 extension UserManager {
     
-    var hasUserNickname: Bool { return self.userNickname != "" }
+    var isUserLogin: Bool { return TokenKeychainManager.shared.hasToken() }
+    var hasUserNickname: Bool { return self.userNickname != nil }
     var getUserNickname: String { return self.userNickname ?? ""}
+    var isTapStart: Bool { return self.tapStart ?? false }
 }
 
 extension UserManager {
+    
+    func setTapStart() {
+        self.tapStart = true
+    }
     
     func setUserNickname(_ nickname: String) {
         self.userNickname = nickname

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
@@ -13,8 +13,8 @@ final class UserManager {
     
     // MARK: - Properties
     
-    @UserDefaultWrapper<String>(key: "userNickname") private(set) var userNickname
-    @UserDefaultWrapper<Bool>(key: "tapStart") private(set) var tapStart
+    @UserDefaultsWrapper<String>(key: "userNickname") private(set) var userNickname
+    @UserDefaultsWrapper<Bool>(key: "tapStart") private(set) var tapStart
     
     private init() {}
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -7,7 +7,7 @@ struct WalkieIOSApp: App {
     
     // TODO: keychain 구현 후에 로컬 값으로 변경해야함
     @State var hasLogin: Bool = false
-    @State var hasNickname: Bool = false
+    @State var hasNickname: Bool = UserManager.shared.hasUserNickname
     
     var body: some Scene {
         WindowGroup {

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -4,25 +4,24 @@ import SwiftUI
 struct WalkieIOSApp: App {
     
     @State var showSplash: Bool = false
+    @State var tapStart: Bool = false
     
-    // TODO: keychain 구현 후에 로컬 값으로 변경해야함
-    @State var hasLogin: Bool = false
-    @State var hasNickname: Bool = UserManager.shared.hasUserNickname
+    @State private var hasLogin: Bool = UserManager.shared.isUserLogin
+    @State private var hasNickname: Bool = UserManager.shared.hasUserNickname
+    @State private var isTapStart: Bool = UserManager.shared.isTapStart
     
     var body: some Scene {
         WindowGroup {
-            if !showSplash { // 스플래시 안보여줌
+            if !showSplash {
                 SplashView(showSplash: $showSplash)
-            } else { // 스플래시 끝남
-                if hasLogin { // 로그인은 했음
-                    if hasNickname { // 닉네임도 지었음
-                        TabBarView()
-                    } else { // 닉네임은 안지음
-                        NicknameView()
-                    }
-                } else { // 로그인 안했음
-                    LoginView()
-                }
+            } else if !hasLogin {
+                LoginView()
+            } else if !hasNickname {
+                NicknameView()
+            } else if isTapStart || tapStart {
+                TabBarView()
+            } else {
+                OnboardingCompleteView(tapStart: $tapStart)
             }
         }
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarItem.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarItem.swift
@@ -48,16 +48,4 @@ enum TabBarItem: CaseIterable {
             return Image(.icMySelected)
         }
     }
-    
-    @ViewBuilder
-    var targetView: some View {
-        switch self {
-        case .home:
-            HomeView(viewModel: HomeViewModel())
-        case .map:
-            MapView(viewModel: MapViewModel())
-        case .mypage:
-            MypageMainView(viewModel: MypageMainViewModel())
-        }
-    }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
@@ -8,13 +8,25 @@
 import SwiftUI
 
 struct TabBarView: View {
+    
+    @StateObject private var homeViewModel = HomeViewModel()
+    @StateObject private var mapViewModel = MapViewModel()
+    @StateObject private var mypageViewModel = MypageMainViewModel()
     @State private var selectedTab: TabBarItem = .home
+    
+    private var viewFactory: TabTargetViewFactory {
+        TabTargetViewFactory(
+            homeViewModel: homeViewModel,
+            mapViewModel: mapViewModel,
+            mypageViewModel: mypageViewModel
+        )
+    }
     
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .bottom) {
                 
-                selectedTab.targetView
+                viewFactory.makeTargetView(for: selectedTab)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 
                 VStack(spacing: 0) {
@@ -77,11 +89,5 @@ struct TabBarView: View {
             }
             .edgesIgnoringSafeArea(.bottom)
         }
-    }
-}
-
-struct CustomTabBar_Previews: PreviewProvider {
-    static var previews: some View {
-        TabBarView()
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabTargetViewFactory.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabTargetViewFactory.swift
@@ -1,0 +1,27 @@
+//
+//  TabTargetViewFactory.swift
+//  Walkie-iOS
+//
+//  Created by ahra on 3/9/25.
+//
+
+import SwiftUI
+
+struct TabTargetViewFactory {
+    
+    let homeViewModel: HomeViewModel
+    let mapViewModel: MapViewModel
+    let mypageViewModel: MypageMainViewModel
+    
+    @ViewBuilder
+    func makeTargetView(for tab: TabBarItem) -> some View {
+        switch tab {
+        case .home:
+            HomeView(viewModel: homeViewModel)
+        case .map:
+            MapView(viewModel: mapViewModel)
+        case .mypage:
+            MypageMainView(viewModel: mypageViewModel)
+        }
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     
-    @StateObject var viewModel: HomeViewModel
+    @ObservedObject var viewModel: HomeViewModel
     @Environment(\.screenWidth) var screenWidth
     @Environment(\.screenHeight) var screenHeight
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -9,51 +9,47 @@ import SwiftUI
 
 struct HomeView: View {
     
-    @ObservedObject var viewModel: HomeViewModel
+    @StateObject var viewModel: HomeViewModel
+    @Environment(\.screenWidth) var screenWidth
+    @Environment(\.screenHeight) var screenHeight
     
     var body: some View {
-        GeometryReader { geometry in
-            VStack {
-                NavigationBar(
-                    showLogo: true,
-                    showAlarmButton: true
-                )
-                
-                switch viewModel.state {
-                case .loaded(let homeState):
-                    ZStack(alignment: .bottomTrailing) {
-                        VStack {
-                            let width = geometry.size.width - 32
-                            HomeStatsView(homeState: homeState, width: width)
-                            HomeCharacterView(homeState: homeState, width: width)
+        VStack(alignment: .center, spacing: 0) {
+            NavigationBar(
+                showLogo: true,
+                showAlarmButton: true
+            )
+            ScrollView(.vertical) {
+                VStack {
+                    switch viewModel.state {
+                    case .loaded(let homeState):
+                        ZStack(alignment: .bottomTrailing) {
+                            VStack {
+                                let width = screenWidth - 32
+                                HomeStatsView(homeState: homeState, width: width)
+                                HomeCharacterView(homeState: homeState, width: width)
+                            }
+                            
+                            Image(homeState.characterImage)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(
+                                    width: 120,
+                                    height: 120)
+                                .padding(.trailing, 8)
                         }
+                        .padding(.top, 8)
                         
-                        Image(homeState.characterImage)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(
-                                width: 120,
-                                height: 120)
-                            .padding(.trailing, 8)
+                        HomeHistoryView(homeState: homeState)
+                            .padding(.top, 18)
+                    default:
+                        ProgressView()
                     }
-                    .padding(.top, 8)
-                    
-                    HomeHistoryView(homeState: homeState)
-                        .padding(.top, 18)
-                    
-                default:
-                    EmptyView()
                 }
             }
         }
         .onAppear {
             viewModel.action(.homeWillAppear)
         }
-    }
-}
-
-struct HomeView_Previews: PreviewProvider {
-    static var previews: some View {
-        HomeView(viewModel: HomeViewModel())
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeViewModel.swift
@@ -30,11 +30,7 @@ final class HomeViewModel: ViewModelable {
         case error(String)
     }
     
-    @Published var state: HomeViewState
-    
-    init() {
-        state = .loading
-    }
+    @Published var state: HomeViewState = .loading
     
     func action(_ action: Action) {
         switch action {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Complete/OnboardingCompleteView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Complete/OnboardingCompleteView.swift
@@ -12,7 +12,7 @@ struct OnboardingCompleteView: View {
     var body: some View {
         VStack {
             VStack(alignment: .center, spacing: 12) {
-                Text("짱짱님,\n환영해요")
+                Text("\(UserManager.shared.getUserNickname)님,\n환영해요")
                     .font(.H2)
                     .foregroundColor(.gray700)
                     .multilineTextAlignment(.center)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Complete/OnboardingCompleteView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Complete/OnboardingCompleteView.swift
@@ -9,45 +9,44 @@ import SwiftUI
 
 struct OnboardingCompleteView: View {
     
+    @Binding var tapStart: Bool
+    
     var body: some View {
-        VStack {
-            VStack(alignment: .center, spacing: 12) {
-                Text("\(UserManager.shared.getUserNickname)님,\n환영해요")
-                    .font(.H2)
-                    .foregroundColor(.gray700)
-                    .multilineTextAlignment(.center)
-                
-                Text("해파리를 선물로 드릴게요")
-                    .font(.B1)
-                    .foregroundColor(.blue400)
-            }
-            .padding(.top, 136)
-            
-            Image(.imgJellyfish0)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 200, height: 200)
-                .padding(.top, 32)
-            
-            Spacer()
-            
-            CTAButton(
-                title: "함께 시작하자!",
-                style: .primary,
-                size: .large,
-                isEnabled: true,
-                buttonAction: {
-                    // TODO: keychain에 nickname 저장
+        NavigationStack {
+            VStack {
+                VStack(alignment: .center, spacing: 12) {
+                    Text("\(UserManager.shared.getUserNickname)님,\n환영해요")
+                        .font(.H2)
+                        .foregroundColor(.gray700)
+                        .multilineTextAlignment(.center)
+                    
+                    Text("해파리를 선물로 드릴게요")
+                        .font(.B1)
+                        .foregroundColor(.blue400)
                 }
-            )
-            .padding(.bottom, 4)
+                .padding(.top, 136)
+                
+                Image(.imgJellyfish0)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
+                    .padding(.top, 32)
+                
+                Spacer()
+                
+                CTAButton(
+                    title: "함께 시작하자!",
+                    style: .primary,
+                    size: .large,
+                    isEnabled: true,
+                    buttonAction: {
+                        tapStart = true
+                        UserManager.shared.setTapStart()
+                    }
+                )
+                .padding(.bottom, 4)
+            }
+            .toolbar(.hidden, for: .navigationBar)
         }
-        .toolbar(.hidden, for: .navigationBar)
-    }
-}
-
-struct OnboardingCompleteView_Previews: PreviewProvider {
-    static var previews: some View {
-        OnboardingCompleteView()
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
@@ -45,7 +45,11 @@ struct LoginView: View {
                 Spacer()
                 
                 Button(action: {
-                    print("kakaobutton tapped")
+                    do {
+                        try TokenKeychainManager.shared.saveAccessToken("test token")
+                    } catch {
+                        print("토큰 저장 실패..")
+                    }
                     isNavigating = true
                 }, label: {
                     HStack(spacing: 8) {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Nickname/NicknameView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Nickname/NicknameView.swift
@@ -13,6 +13,7 @@ struct NicknameView: View {
     @State private var isButtonEnabled: Bool = false
     @State private var inputState: InputState = .default
     @State private var isNavigating: Bool = false
+    @State private var tapStart: Bool = false
     
     var body: some View {
         NavigationStack {
@@ -57,9 +58,9 @@ struct NicknameView: View {
             .gesture(DragGesture().onChanged { _ in
                 hideKeyboard()
             })
-        }
-        .navigationDestination(isPresented: $isNavigating) {
-            OnboardingCompleteView()
+            .navigationDestination(isPresented: $isNavigating) {
+                OnboardingCompleteView(tapStart: $tapStart)
+            }
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Nickname/NicknameView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Nickname/NicknameView.swift
@@ -22,8 +22,8 @@ struct NicknameView: View {
                     showRightButton: true,
                     rightButtonEnabled: isButtonEnabled,
                     rightButtonAction: {
-                        print("rightbuttontapped")
                         isNavigating = true
+                        UserManager.shared.setUserNickname(userInput)
                     }
                 )
                 

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SpalshView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SpalshView.swift
@@ -20,6 +20,20 @@ struct SplashView: View {
                 .onAppear {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                         showSplash = true
+                        
+                        print("🌀🌀🌀🌀userinfo🌀🌀🌀🌀")
+                        do {
+                            let token = try TokenKeychainManager.shared.getAccessToken()
+                            print(token ?? "no token")
+                        } catch {
+                            print("issue;;")
+                        }
+                        print("isUserLogin")
+                        print(UserManager.shared.isUserLogin)
+                        print("nickname")
+                        print(UserManager.shared.userNickname ?? "no nickname")
+                        print("tapstart")
+                        print(UserManager.shared.tapStart ?? false)
                     }
                 }
         }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
- Keychain 구현 (accesstoken, refreshtoken 저장)
- UserManager 구현(닉네임, 온보딩 중 이탈여부 저장)
- 홈뷰 스크롤 가능하게 변경

🚨 **참고 사항**
- 현재 카카오로그인 누르면 "test token" 저장되도록 구현해놨습니다.
- 온보딩 이탈 저장 시점: 로그인, 닉네임입력, 시작하기 버튼 탭 (기획과 논의 완)
- 만약 온보딩을 다 안했는데 앱을 지웠다? -> 로그인 시에 서버에서 받아오는 data로 판단해야할거 같아요!(닉네임 있는지 / 204로 오는지)

🤓 **@StateObject와 @ObservedObject**
- 초기에 홈뷰에서 `@ObservedObject var viewModel: HomeViewModel`로 선언하고 `TabBarItem`의 `targetView`에서 매번 인스턴스 생성해서 뷰를 만드는 플로우였습니다. 이렇게 하니까 리렌더링 되면 인스턴스 계속 생성되면서 state가 꼬이는 이슈 발생! 화면이 사라지던데요,,
- 해결방법 : 뷰 모델 생성과 관리는 TabBarView가 맡고, TabTargetViewFactory는 단순히 뷰를 만드는 역할을 하도록 책임을 분리~
```swift
struct TabBarView: View {
    
    @StateObject private var homeViewModel = HomeViewModel()
    @StateObject private var mapViewModel = MapViewModel()
    @StateObject private var mypageViewModel = MypageMainViewModel()
    @State private var selectedTab: TabBarItem = .home
    
    private var viewFactory: TabTargetViewFactory {
        TabTargetViewFactory(
            homeViewModel: homeViewModel,
            mapViewModel: mapViewModel,
            mypageViewModel: mypageViewModel
        )
    }
}
```

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/3ba05dc4-1cbd-4ba0-b232-968707a80a24" width ="250">|

📟 **관련 이슈**
- Resolved: #44 
