### PR TITLE
[Feat] #93 - 푸시 알림 설정 로직 구현

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/PushNotificationManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/PushNotificationManager.swift
@@ -66,4 +66,14 @@ final class NotificationManager {
             }
         }
     }
+    
+    func clearBadge() {
+        UNUserNotificationCenter.current().setBadgeCount(0) { error in
+            if let error = error {
+                print("ERROR: Failed to clear badge - \(error)")
+            } else {
+                print("SUCCESS: Badge cleared")
+            }
+        }
+    }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/PushNotificationManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/PushNotificationManager.swift
@@ -53,12 +53,16 @@ final class NotificationManager {
         // 알림 요청 생성
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
         
-        // 알림 센터에 추가
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-                print("ERROR: Failed to schedule notification - \(error)")
-            } else {
-                print("SUCCESS: Notification scheduled with identifier \(identifier)")
+        // 권한이 허용된 경우에만 알림 센터에 추가
+        NotificationManager.shared.requestAuthorization { granted in
+            if granted && NotificationManager.shared.getNotificationMode() {
+                UNUserNotificationCenter.current().add(request) { error in
+                    if let error = error {
+                        print("ERROR: Failed to schedule notification - \(error)")
+                    } else {
+                        print("SUCCESS: Notification scheduled with identifier \(identifier)")
+                    }
+                }
             }
         }
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -8,11 +8,6 @@ struct WalkieIOSApp: App {
     
     init() {
         _ = StepManager.shared
-        NotificationManager.shared.requestAuthorization { granted in
-            if granted && NotificationManager.shared.getNotificationMode() {
-                NotificationManager.shared.scheduleNotification(title: "푸시 알림", body: "테스트")
-            }
-        }
         let kakaoNativeAppKey = (Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String) ?? ""
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -8,6 +8,7 @@ struct WalkieIOSApp: App {
     
     init() {
         _ = StepManager.shared
+        NotificationManager.shared.clearBadge()
         let kakaoNativeAppKey = (Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String) ?? ""
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -8,6 +8,11 @@ struct WalkieIOSApp: App {
     
     init() {
         _ = StepManager.shared
+        NotificationManager.shared.requestAuthorization { granted in
+            if granted && NotificationManager.shared.getNotificationMode() {
+                NotificationManager.shared.scheduleNotification(title: "푸시 알림", body: "테스트")
+            }
+        }
         let kakaoNativeAppKey = (Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String) ?? ""
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Step/Implementation/DefaultCheckStepUseCase.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Step/Implementation/DefaultCheckStepUseCase.swift
@@ -12,7 +12,10 @@ final class DefaultCheckStepUseCase: BaseStepUseCase, CheckStepUseCase {
         if UserManager.shared.getStepCountGoal
             >= UserManager.shared.getStepCount
             + stepStore.getStepCountCache() {
-            // 푸시 알림 전송
+            NotificationManager.shared.scheduleNotification(
+                title: "알이 부화하려고 해요!",
+                body: "어서 가서 깨워주세요"
+            )
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/PushNotification/MypagePushNotificationView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/PushNotification/MypagePushNotificationView.swift
@@ -11,6 +11,8 @@ struct MypagePushNotificationView: View {
     
     @ObservedObject var viewModel: MypageMainViewModel
     
+    @State var isOn: Bool = NotificationManager.shared.getNotificationMode()
+    
     var body: some View {
         NavigationBar(
             title: "푸시 알림",
@@ -23,12 +25,18 @@ struct MypagePushNotificationView: View {
                     SwitchOptionItemView(
                         title: "알 부화 알림",
                         subtitle: "알이 부화하면 알려드려요",
-                        isOn: NotificationManager.shared.getNotificationMode(),
-                        toggle: { viewModel.action(.toggleNotifyEggHatches) }
+                        isOn: isOn,
+                        toggle: {
+                            viewModel.action(.toggleNotifyEggHatches)
+                            isOn.toggle()
+                        }
                     )
                 }
                 .padding(.top, 12)
                 .padding(.horizontal, 16)
+        }
+        .onAppear {
+            isOn = NotificationManager.shared.getNotificationMode()
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

## 알 부화 푸시 알림 허용/비허용 설정 로직 구현
알림 권한은 2가지로 나뉩니다

### A : 워키 앱 알림 설정 허용 여부
### B : 알 부화 푸시 알림 허용 여부

A는 앱 설치 이후 처음 사용 시 요청을 받습니다
이때, A의 허용 여부를 B에 그대로 반영합니다

B는 워키 마이페이지에서 수정이 가능합니다.
B의 권한 설정은 A(앱 전체 권한)과는 별개이기 때문에(나중에 다른 알림이 생기는 경우를 고려) 독립적으로 관리됩니다

알 부화 알림 스케줄링은 `if A && B`의 경우에만 작동합니다

만약 A와 B 모두 허용을 했다가 A를 설정창에서 바꾼 경우, 
앱 진입 시 검사하여 A의 비허용을 B에도 반영합니다

## 기타
- 앱 진입 시 알림 뱃지 초기화 로직 구현
- 푸시알림 터치 시 앱 실행

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->
- 테스트를 위해 스케줄링 이후 10초 후 알림이 가도록 구현해논 상태입니다(수정 가능)
- 알림 배지 개수가 누적이 아니라 설정대로 덮어씌워지는 방식인데, 디자인팀에 전달해서 어떻게할지 여쭤봐야할 것 같습니다
  - 개수를 누적시키고 싶은 경우 별도 데이터 관리 필요

📸 **스크린샷**

https://github.com/user-attachments/assets/1db4c0e8-f7f4-41c5-ae4b-7acd38821a6c



📟 **관련 이슈**
- Resolved: #이슈번호
