### PR TITLE
[Fix] #103 - 캘린더 초기 조회 실패 수정

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -129,6 +129,9 @@ final class DIContainer {
             )
         )
     }()
+    private lazy var calendarViewModel: CalendarViewModel = {
+        CalendarViewModel(reviewViewModel: reviewViewModel)
+    }()
 }
 
 extension DIContainer {
@@ -150,7 +153,10 @@ extension DIContainer {
         return AlarmListView(viewModel: alarmListViewModel)
     }
     func buildReviewView() -> ReviewView {
-        return ReviewView(viewModel: reviewViewModel)
+        return ReviewView(
+            viewModel: reviewViewModel,
+            calendarViewModel: calendarViewModel
+        )
     }
     func buildCharacterView() -> CharacterView {
         return CharacterView(viewModel: characterViewModel)

--- a/Walkie-iOS/Walkie-iOS/Sources/Data/Dto/Character/GetCharactersDetailDto.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Data/Dto/Character/GetCharactersDetailDto.swift
@@ -11,6 +11,6 @@ struct GetCharactersDetailDto: Codable {
     let obtainedDetails: [ObtainedDetail]
     struct ObtainedDetail: Codable {
         let obtainedPosition: String
-        let obtainedDate: [Int]
+        let obtainedDate: String
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Data/Repository/Egg/DefaultEggRepository.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Data/Repository/Egg/DefaultEggRepository.swift
@@ -26,66 +26,37 @@ final class DefaultEggRepository {
 
 extension DefaultEggRepository: EggRepository {
     
-    func getEggsList(dummy: Bool = false) -> AnyPublisher<[EggEntity], NetworkError> {
-        if dummy {
-            let dummyData = (0..<20).map { eggId in
-                EggEntity(
-                    eggId: eggId,
-                    eggType: EggType.from(number: Int.random(in: 0...3)),
-                    nowStep: Int.random(in: 0...5000),
-                    needStep: Int.random(in: 1...5) * 1000,
-                    isWalking: Bool.random(),
-                    detail: nil,
-                    characterType: nil,
-                    jellyFishType: nil,
-                    dinoType: nil
-                )
-            }
-            return Just(dummyData)
-                .setFailureType(to: NetworkError.self)
-                .mapToNetworkError()
-        } else {
-            return eggService.getEggsList()
-                .map { dto in
-                    dto.eggs.map { egg in
-                        EggEntity(
-                            eggId: egg.eggId,
-                            eggType: EggType.from(number: egg.rank),
-                            nowStep: egg.nowStep,
-                            needStep: egg.needStep,
-                            isWalking: egg.play,
-                            detail: EggDetailEntity(
-                                obtainedPosition: egg.obtainedPosition,
-                                obtainedDate: egg.obtainedDate
-                            ),
-                            characterType: nil,
-                            jellyFishType: nil,
-                            dinoType: nil
-                        )
-                    }
-                }.mapToNetworkError()
-        }
-    }
-    
-    func getEggDetail(dummy: Bool = false, eggId: Int) -> AnyPublisher<EggDetailEntity, NetworkError> {
-        if dummy {
-            let dummyData = EggDetailEntity(
-                obtainedPosition: "부평구 삼산동",
-                obtainedDate: "2023-04-15"
-            )
-            return Just(dummyData)
-                .setFailureType(to: NetworkError.self)
-                .mapToNetworkError()
-        } else {
-            return eggService.getEggDetail(eggId: eggId)
-                .map { dto in
-                    EggDetailEntity(
-                        obtainedPosition: dto.obtainedPosition,
-                        obtainedDate: dto.obtainedDate
+    func getEggsList() -> AnyPublisher<[EggEntity], NetworkError> {
+        return eggService.getEggsList()
+            .map { dto in
+                dto.eggs.map { egg in
+                    EggEntity(
+                        eggId: egg.eggId,
+                        eggType: EggType.from(number: egg.rank),
+                        nowStep: egg.nowStep,
+                        needStep: egg.needStep,
+                        isWalking: egg.play,
+                        detail: EggDetailEntity(
+                            obtainedPosition: egg.obtainedPosition,
+                            obtainedDate: egg.obtainedDate
+                        ),
+                        characterType: nil,
+                        jellyFishType: nil,
+                        dinoType: nil
                     )
                 }
-                .mapToNetworkError()
-        }
+            }.mapToNetworkError()
+    }
+    
+    func getEggDetail(eggId: Int) -> AnyPublisher<EggDetailEntity, NetworkError> {
+        return eggService.getEggDetail(eggId: eggId)
+            .map { dto in
+                EggDetailEntity(
+                    obtainedPosition: dto.obtainedPosition,
+                    obtainedDate: dto.obtainedDate
+                )
+            }
+            .mapToNetworkError()
     }
     
     func patchEggStep(requestBody: PatchEggStepRequestDto) -> AnyPublisher<Void, NetworkError> {

--- a/Walkie-iOS/Walkie-iOS/Sources/Data/Repository/Egg/EggRepository.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Data/Repository/Egg/EggRepository.swift
@@ -8,8 +8,8 @@
 import Combine
 
 protocol EggRepository {
-    func getEggsList(dummy: Bool) -> AnyPublisher<[EggEntity], NetworkError>
-    func getEggDetail(dummy: Bool, eggId: Int) -> AnyPublisher<EggDetailEntity, NetworkError>
+    func getEggsList() -> AnyPublisher<[EggEntity], NetworkError>
+    func getEggDetail(eggId: Int) -> AnyPublisher<EggDetailEntity, NetworkError>
     func patchEggStep(requestBody: PatchEggStepRequestDto) -> AnyPublisher<Void, NetworkError>
     func getEggsCount() -> AnyPublisher<Int, NetworkError>
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Data/Service/Egg/EggTarget.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Data/Service/Egg/EggTarget.swift
@@ -42,7 +42,7 @@ extension EggTarget {
     static func getEggDetail(eggId: Int) -> EggTarget {
         EggTarget(
             path: URLConstant.eggsDetail(eggId: eggId),
-            method: .patch,
+            method: .get,
             task: .requestPlain
         )
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/Entity/Character/CharacterDetailEntity.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/Entity/Character/CharacterDetailEntity.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct CharacterDetailEntity {
     let obtainedPosition: String
-    let obtainedDate: [Int]
+    let obtainedDate: String
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/Entity/Character/CharacterEntity.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/Entity/Character/CharacterEntity.swift
@@ -14,5 +14,5 @@ struct CharacterEntity {
     let dinoType: DinoType?
     let count: Int
     let isWalking: Bool
-    let obtainedDetails: [Int]?
+    let obtainedDetails: String?
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Egg/DefaultEggUseCase.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Egg/DefaultEggUseCase.swift
@@ -34,12 +34,12 @@ extension DefaultEggUseCase: EggUseCase {
     }
     
     func getEggsList() -> AnyPublisher<[EggEntity], NetworkError> {
-        eggRepository.getEggsList(dummy: false)
+        eggRepository.getEggsList()
             .mapToNetworkError()
     }
     
     func getEggDetail(eggId: Int) -> AnyPublisher<EggDetailEntity, NetworkError> {
-        eggRepository.getEggDetail(dummy: false, eggId: eggId)
+        eggRepository.getEggDetail(eggId: eggId)
             .mapToNetworkError()
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Character/ViewModels/CharacterDetailViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Character/ViewModels/CharacterDetailViewModel.swift
@@ -73,7 +73,9 @@ final class CharacterDetailViewModel: ViewModelable {
                 receiveValue: { _, details in
                     self.obtainedState = details.map { detail in
                         ObtainedState(
-                            obtainedDate: "\(detail.obtainedDate[0]).\(detail.obtainedDate[1]).\(detail.obtainedDate[2])",
+                            obtainedDate: self.convertDateFormat(
+                                from: detail.obtainedDate
+                            ) ?? "날짜 변환 오류",
                             obtainedPosition: detail.obtainedPosition)
                     }
                     self.state = .loaded(

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Egg/ViewModels/EggDetailViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Egg/ViewModels/EggDetailViewModel.swift
@@ -60,7 +60,7 @@ final class EggDetailViewModel: ViewModelable {
                             eggType: self.eggState.eggType,
                             nowStep: self.eggState.nowStep,
                             needStep: self.eggState.needStep,
-                            isWalking: true
+                            isWalking: self.eggState.isWalking
                         )
                     )
                 }, receiveFailure: { _, error in

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/ViewModel/MypageMainViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/ViewModel/MypageMainViewModel.swift
@@ -14,6 +14,7 @@ final class MypageMainViewModel: ViewModelable {
     private let patchProfileUseCase: PatchProfileUseCase
     private let getProfileUseCase: GetProfileUseCase
     private let withdrawUseCase: WithdrawUseCase
+    @EnvironmentObject private var appCoordinator: AppCoordinator
     
     var hasFetchedInitialData = false
     
@@ -148,11 +149,12 @@ final class MypageMainViewModel: ViewModelable {
             .walkieSink(
                 with: self,
                 receiveValue: { _, _ in
-                    UserManager.shared.withdraw()
+                    self.appCoordinator.changeRoot()
                 }, receiveFailure: { _, error  in
                     let errorMessage = error?.description ?? "An unknown error occurred"
                     self.state = .error(errorMessage)
                 }
             )
-        .store(in: &self.cancellables)    }
+            .store(in: &self.cancellables)
+    }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Withdraw/MypageWithdrawView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Withdraw/MypageWithdrawView.swift
@@ -20,9 +20,9 @@ struct MypageWithdrawView: View {
             showBackButton: true
         ).padding(.bottom, 40)
         switch viewModel.state {
-        case .loaded:
+        case .loaded(let state) :
             VStack(alignment: .center, spacing: 0) {
-                Text("\(UserManager.shared.getUserNickname)님이 떠나시다니,\n너무 아쉬워요")
+                Text("\(state.nickname)님이 떠나시다니,\n너무 아쉬워요")
                     .font(.H3)
                     .foregroundStyle(WalkieCommonAsset.gray700.swiftUIColor)
                     .multilineTextAlignment(.center)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Withdraw/MypageWithdrawView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Withdraw/MypageWithdrawView.swift
@@ -20,7 +20,7 @@ struct MypageWithdrawView: View {
             showBackButton: true
         ).padding(.bottom, 40)
         switch viewModel.state {
-        case .loaded(let state) :
+        case .loaded(let state):
             VStack(alignment: .center, spacing: 0) {
                 Text("\(state.nickname)님이 떠나시다니,\n너무 아쉬워요")
                     .font(.H3)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/Calendar/CalendarViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/Calendar/CalendarViewModel.swift
@@ -251,7 +251,14 @@ final class CalendarViewModel: ViewModelable {
         )
         if let last = self.lastQuery, last.startDate != query.startDate {
             lastQuery = query
-            reviewViewModel.action(.loadReviewList(startDate: query.startDate, endDate: query.endDate))
+            reviewViewModel
+                .action(
+                    .loadReviewList(
+                        startDate: query.startDate,
+                        endDate: query.endDate,
+                        completion: { _ in }
+                    )
+                )
         }
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
@@ -60,10 +60,21 @@ struct ReviewView: View {
             }
         }
         .onAppear {
-            viewModel.action(.loadReviewList(
-                startDate: calendarViewModel.firstDay.convertToDateString(),
-                endDate: calendarViewModel.lastDay.convertToDateString()
-            ))
+            viewModel.action(
+                .loadReviewList(
+                    startDate: calendarViewModel.firstDay.convertToDateString(),
+                    endDate: calendarViewModel.lastDay.convertToDateString(),
+                    completion: { result in
+                        if result {
+                            viewModel.action(
+                                .showReviewList(
+                                    dateString: Date().convertToDateString()
+                                )
+                            )
+                        }
+                    }
+                )
+            )
         }
         .navigationBarBackButtonHidden()
         .bottomSheet(isPresented: $calendarViewModel.showPicker, height: 436) {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
@@ -13,13 +13,6 @@ struct ReviewView: View {
     @ObservedObject var viewModel: ReviewViewModel
     @ObservedObject var calendarViewModel: CalendarViewModel
     
-    init(
-        viewModel: ReviewViewModel
-    ) {
-        self.viewModel = viewModel
-        self.calendarViewModel = CalendarViewModel(reviewViewModel: viewModel)
-    }
-    
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             NavigationBar(
@@ -66,11 +59,7 @@ struct ReviewView: View {
                     endDate: calendarViewModel.lastDay.convertToDateString(),
                     completion: { result in
                         if result {
-                            viewModel.action(
-                                .showReviewList(
-                                    dateString: Date().convertToDateString()
-                                )
-                            )
+                            calendarViewModel.action(.didTapTodayButton)
                         }
                     }
                 )

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
@@ -18,7 +18,7 @@ final class ReviewViewModel: ViewModelable {
     @Published var reviewDateList: [String] = []
     
     enum Action {
-        case loadReviewList(startDate: String, endDate: String)
+        case loadReviewList(startDate: String, endDate: String, completion: (Bool) -> Void)
         case showReviewList(dateString: String)
     }
     
@@ -45,8 +45,8 @@ final class ReviewViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
-        case .loadReviewList(let startDate, let endDate):
-            getReviewList(startDate: startDate, endDate: endDate)
+        case .loadReviewList(let startDate, let endDate, let completion):
+            getReviewList(startDate: startDate, endDate: endDate, completion: completion)
         case .showReviewList(dateString: let dateString):
             showReviewList(dateString: dateString)
         }
@@ -56,7 +56,7 @@ final class ReviewViewModel: ViewModelable {
         self.reviewUseCase = reviewUseCase
     }
     
-    func getReviewList(startDate: String, endDate: String) {
+    func getReviewList(startDate: String, endDate: String, completion: @escaping (Bool) -> Void) {
         let date = ReviewsCalendarDate(startDate: startDate, endDate: endDate)
         self.reviewUseCase.getReviewList(date: date)
             .walkieSink(
@@ -65,17 +65,23 @@ final class ReviewViewModel: ViewModelable {
                     let processedReviews = reviewList.reviewList.map { viewModel.processReviewEntity($0) }
                     viewModel.loadedReviewList = processedReviews
                     viewModel.reviewDateList = Array(Set(reviewList.reviewList.map { $0.date })).sorted()
+                    completion(true)
                 }, receiveFailure: { _, error in
                     let errorMessage = error?.description ?? "An unknown error occurred"
                     self.state = .error(errorMessage)
+                    completion(false)
                 })
             .store(in: &cancellables)
     }
     
     func showReviewList(dateString: String) {
-        self.state = .loaded(self.loadedReviewList.filter { review in
-            review.date == dateString
-        })
+        DispatchQueue.main.async {
+            self.state = .loaded(
+                self.loadedReviewList.filter { review in
+                    review.date == dateString
+                }
+            )
+        }
     }
 }
 

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
@@ -18,7 +18,7 @@ final class ReviewViewModel: ViewModelable {
     @Published var reviewDateList: [String] = []
     
     enum Action {
-        case loadReviewList(startDate: String, endDate: String, completion: (Bool) -> Void)
+        case loadReviewList(startDate: String, endDate: String)
         case showReviewList(dateString: String)
     }
     
@@ -45,8 +45,8 @@ final class ReviewViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
-        case .loadReviewList(let startDate, let endDate, let completion):
-            getReviewList(startDate: startDate, endDate: endDate, completion: completion)
+        case .loadReviewList(let startDate, let endDate):
+            getReviewList(startDate: startDate, endDate: endDate)
         case .showReviewList(dateString: let dateString):
             showReviewList(dateString: dateString)
         }
@@ -56,7 +56,7 @@ final class ReviewViewModel: ViewModelable {
         self.reviewUseCase = reviewUseCase
     }
     
-    func getReviewList(startDate: String, endDate: String, completion: @escaping (Bool) -> Void) {
+    func getReviewList(startDate: String, endDate: String) {
         let date = ReviewsCalendarDate(startDate: startDate, endDate: endDate)
         self.reviewUseCase.getReviewList(date: date)
             .walkieSink(
@@ -65,11 +65,9 @@ final class ReviewViewModel: ViewModelable {
                     let processedReviews = reviewList.reviewList.map { viewModel.processReviewEntity($0) }
                     viewModel.loadedReviewList = processedReviews
                     viewModel.reviewDateList = Array(Set(reviewList.reviewList.map { $0.date })).sorted()
-                    completion(true)
                 }, receiveFailure: { _, error in
                     let errorMessage = error?.description ?? "An unknown error occurred"
                     self.state = .error(errorMessage)
-                    completion(false)
                 })
             .store(in: &cancellables)
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
@@ -18,7 +18,7 @@ final class ReviewViewModel: ViewModelable {
     @Published var reviewDateList: [String] = []
     
     enum Action {
-        case loadReviewList(startDate: String, endDate: String)
+        case loadReviewList(startDate: String, endDate: String, completion: (Bool) -> Void)
         case showReviewList(dateString: String)
     }
     
@@ -45,8 +45,8 @@ final class ReviewViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
-        case .loadReviewList(let startDate, let endDate):
-            getReviewList(startDate: startDate, endDate: endDate)
+        case .loadReviewList(let startDate, let endDate, let completion):
+            getReviewList(startDate: startDate, endDate: endDate, completion: completion)
         case .showReviewList(dateString: let dateString):
             showReviewList(dateString: dateString)
         }
@@ -56,7 +56,7 @@ final class ReviewViewModel: ViewModelable {
         self.reviewUseCase = reviewUseCase
     }
     
-    func getReviewList(startDate: String, endDate: String) {
+    func getReviewList(startDate: String, endDate: String, completion: @escaping (Bool) -> Void) {
         let date = ReviewsCalendarDate(startDate: startDate, endDate: endDate)
         self.reviewUseCase.getReviewList(date: date)
             .walkieSink(
@@ -65,9 +65,11 @@ final class ReviewViewModel: ViewModelable {
                     let processedReviews = reviewList.reviewList.map { viewModel.processReviewEntity($0) }
                     viewModel.loadedReviewList = processedReviews
                     viewModel.reviewDateList = Array(Set(reviewList.reviewList.map { $0.date })).sorted()
+                    completion(true)
                 }, receiveFailure: { _, error in
                     let errorMessage = error?.description ?? "An unknown error occurred"
                     self.state = .error(errorMessage)
+                    completion(false)
                 })
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- #103 참고해주세요!

--- 5월 9일 추가 ---
- 알 세부정보 관련 Dto 구조 변경사항 롤백 반영
- HTTP 메소드 종류 잘못된 점 수정
- 탈퇴하기 뷰 닉네임 연결
- Service 계층 더미데이터 로직 삭제
- 캘린더 뷰모델 싱글톤 관리
  - 네비게이션 스택 스와이프 시도하는 경우(스와이프 끝까지 하지 않아도) 오늘 날짜로 초기화 되는 오류 수정
  - 캘린더는 오늘 날짜, 캘린더 뷰모델에서 제어하는 리뷰 리스트도 오늘 날짜로 필터링 되는 오류 수정
  - 스팟 리뷰 뷰 UX 안정성 향상

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->
- 클로저 사용하여 완료 감지하고, 오늘로 필터링 되도록 구현하였습니다
  `.walkieSink` 메소드의 `receiveValue` 클로저 내부에서 해도 되긴 하는데, 함수별 분리를 명확히 하기 위해서 이렇게 구현하였습니다
  혹시 더 좋은 방법이 있으면 리뷰해주세요!!
- 캘린더 바텀시트 업데이트 로직도 테스트 못해봤는데, #102로 수정되지 않았을까 싶네요
- 캘린더 뷰모델 관련 수정사항 비교 영상을 촬영하려 했는데, 
  탈퇴 API 테스트하다가 또 다른 이슈가 생겨서 현재 제 카카오톡, 애플 계정 모두 막혀버린 상황이라..

📸 **스크린샷**

📟 **관련 이슈**
- Resolved: #103 
