### PR TITLE
[Feat/Fix] #112 - 스팟탐험동안 걸음수 측정 구현 및 QA 반영

### DIFF
--- a/Walkie-iOS/Project.swift
+++ b/Walkie-iOS/Project.swift
@@ -2,6 +2,10 @@ import ProjectDescription
 
 let project = Project(
     name: "Walkie-iOS",
+    options: .options(
+        defaultKnownRegions: ["ko"],
+        developmentRegion: "ko"
+    ),
     targets: [
         .target(
             name: "Walkie-iOS",

--- a/Walkie-iOS/Project.swift
+++ b/Walkie-iOS/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
             infoPlist: .extendingDefault(
                 with: [
                     "CFBundleDisplayName": "Walkie",
-                    "CFBundleShortVersionString": "1.0.0",
+                    "CFBundleShortVersionString": "1.0.1",
                     "UILaunchScreen": [
                         "UIColorName": "",
                         "UIImageName": "",
@@ -93,7 +93,7 @@ let project = Project(
             settings: .settings(
                 base: [
                     "ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "YES",
-                    "MARKETING_VERSION": "1.0.0"
+                    "MARKETING_VERSION": "1.0.1"
                 ],
                 configurations: [
                     .debug(name: "Debug", xcconfig: "Config/WalkieConfig.xcconfig"),

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/UserManager.swift
@@ -16,6 +16,7 @@ final class UserManager {
     @UserDefaultsWrapper<String>(key: "nickname") private(set) var nickname
     @UserDefaultsWrapper<Int>(key: "stepCount") private(set) var stepCount
     @UserDefaultsWrapper<Int>(key: "stepCountGoal") private(set) var stepCountGoal
+    @UserDefaultsWrapper<Date>(key: "startExploreDate") private(set) var startExploreDate
     
     private init() {}
 }
@@ -26,6 +27,7 @@ extension UserManager {
     var getUserNickname: String { return self.nickname ?? "" }
     var getStepCount: Int { return self.stepCount ?? 0 }
     var getStepCountGoal: Int { return self.stepCountGoal ?? .max }
+    var getStartExploreDate: Date? { return self.startExploreDate }
 }
 
 extension UserManager {
@@ -40,6 +42,14 @@ extension UserManager {
     
     func setStepCountGoal(_ count: Int) {
         self.stepCountGoal = count
+    }
+    
+    func setStartExploreDate(_ date: Date) {
+        self.startExploreDate = date
+    }
+    
+    func clearExploreDate() {
+        self.startExploreDate = nil
     }
     
     func withdraw() {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
@@ -291,6 +291,11 @@ private extension MapViewModel {
                 return
             }
             
+            if distance > total {
+                print("🔁 총 거리 갱신")
+                self.totalDistance = distance
+            }
+            
             if let last = self.lastLocation {
                 let moved = userLoc.distance(from: last)
                 if moved < 10 {
@@ -312,7 +317,7 @@ private extension MapViewModel {
             let updated = WalkieWidgetAttributes.ContentState(
                 place: self.placeName,
                 leftDistance: distance,
-                totalDistance: total
+                totalDistance: self.totalDistance ?? total
             )
             print(updated)
             Task {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
@@ -69,7 +69,7 @@ final class MapViewModel: ViewModelable, WebMessageHandling {
         case .haptic:
             triggerHaptic()
         case .startCountingSteps:
-            break
+            startCount()
         case .finishWebView:
             finishWebView()
         case .startExplore:
@@ -131,10 +131,6 @@ private extension MapViewModel {
     func triggerHaptic() {
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
-    }
-    
-    func startCountingSteps() {
-        startCount()
     }
     
     func finishWebView() {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
@@ -17,17 +17,11 @@ final class MapViewModel: ViewModelable, WebMessageHandling {
     
     enum Action {
         case mapViewAppear
-        case mapViewDisappear
-    }
-    
-    struct MapState {
-        let step: Int
-        let distance: Double
     }
     
     enum MapViewState {
         case loading
-        case loaded(MapState)
+        case loaded
         case error
     }
     
@@ -52,7 +46,6 @@ final class MapViewModel: ViewModelable, WebMessageHandling {
     
     @Published var stepData: Int = 0
     @Published var distanceData: Double = 0
-    @Published var exploreStep: Int = 1234
     @Published var webRequest: URLRequest?
     
     private let getCharacterPlayUseCase: GetCharacterPlayUseCase
@@ -68,8 +61,6 @@ final class MapViewModel: ViewModelable, WebMessageHandling {
         switch action {
         case .mapViewAppear:
             getCharacterPlay()
-        case .mapViewDisappear:
-            stopStepUpdates()
         }
     }
     
@@ -143,7 +134,7 @@ private extension MapViewModel {
     }
     
     func startCountingSteps() {
-        print("✅ Starting step counting")
+        startCount()
     }
     
     func finishWebView() {
@@ -152,7 +143,7 @@ private extension MapViewModel {
     }
     
     func sendStep() {
-        sendToWeb?(exploreStep)
+        stopCount()
         updateArriveActivity()
         
         locationCancellable?.cancel()
@@ -163,36 +154,35 @@ private extension MapViewModel {
 // step
 private extension MapViewModel {
     
-    func startStepUpdates() {
+    func startCount() {
         guard CMPedometer.isStepCountingAvailable() else { return }
-        
         let now = Date()
-        let startOfDay = Calendar.current.startOfDay(for: now)
+        UserManager.shared.setStartExploreDate(now)
+        print("✅ 걸음 수 측정 시작: \(now)")
+    }
+    
+    func stopCount() {
+        guard let start = UserManager.shared.getStartExploreDate else { return }
+        let end = Date()
+        print("걸음수 시작 시간 : \(start)")
+        print("걸음 수 측정 종료: \(end)")
         
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.pedometer.startUpdates(from: startOfDay) { data, error in
-                guard let self = self else { return }
-                
-                if let data = data, error == nil {
-                    DispatchQueue.main.async {
-                        let newStepData = data.numberOfSteps.intValue
-                        let newDistanceData = (data.distance?.doubleValue ?? 0.0) / 1000.0
-                        self.updateStepData(step: newStepData, distance: newDistanceData)
-                    }
+        pedometer.queryPedometerData(
+            from: start,
+            to: end
+        ) { [weak self] data, error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    print("🚫 걸음 수 쿼리 실패: \(error)")
+                }
+                if let data = data {
+                    let totalSteps = data.numberOfSteps.intValue
+                    print("✅ 총 걸음 수: \(totalSteps)걸음")
+                    self?.sendToWeb?(totalSteps)
+                    UserManager.shared.clearExploreDate()
                 }
             }
         }
-    }
-    
-    func stopStepUpdates() {
-        timer?.invalidate()
-        timer = nil
-        pedometer.stopUpdates()
-    }
-    
-    func updateStepData(step: Int, distance: Double) {
-        let mapState = MapState(step: step, distance: distance)
-        state = .loaded(mapState)
     }
 }
 

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewViewModel.swift
@@ -159,7 +159,10 @@ private extension ReviewViewModel {
         }()
         
         let formattedDistance = String(format: "%.1f", entity.distance) + "km"
-        let duration = timeDifferenceInMinutes(startTime: entity.startTime, endTime: entity.endTime).map { "\($0)m" }
+        let duration = timeDifferenceString(
+            startTime: entity.startTime,
+            endTime: entity.endTime
+        )
         
         return ReviewState(
             reviewID: entity.reviewID,
@@ -181,19 +184,28 @@ private extension ReviewViewModel {
         )
     }
     
-    func timeDifferenceInMinutes(startTime: String, endTime: String) -> Int? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "HH:mm:ss"
+    func timeDifferenceString(startTime: String, endTime: String) -> String? {
+        let df = DateFormatter()
+        df.dateFormat = "HH:mm:ss"
+        guard
+            let start = df.date(from: startTime),
+            let end = df.date(from: endTime)
+        else { return nil }
         
-        if
-            let start = dateFormatter.date(from: startTime),
-            let end = dateFormatter.date(from: endTime) {
-            let difference = end.timeIntervalSince(start)
-            return Int(difference / 60)
+        let totalMinutes = Int(end.timeIntervalSince(start) / 60)
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        
+        switch (hours, minutes) {
+        case (0, let m):
+            return "\(m)분"
+        case (let h, 0):
+            return "\(h)시간"
+        default:
+            return "\(hours)시간 \(minutes)분"
         }
-        return nil
     }
-    
+
     func formatTimeString(_ timeString: String) -> String? {
         let inputFormatter = DateFormatter()
         inputFormatter.dateFormat = "HH:mm:ss"


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 스팟 탐험 동안 걸음수 측정 구현
- 스팟 탐험을 시작했을 때의 `Date`를 `UserManager`에 저장
- 걸음수 요청하는 브릿지 왔을 때 저장된 시작 `Date`를 불러와서 현재 시간 사이의 걸음수 측정 -> `CoreMotion`에서 제공!
```swift
pedometer.queryPedometerData(
            from: start,
            to: end
        ) { [weak self] data, error in
            DispatchQueue.main.async {
                if let data = data {
                    let totalSteps = data.numberOfSteps.intValue
                    self?.sendToWeb?(totalSteps)
                }
            }
        }
```

### 라이브액티비티 수정
- 처음 로직은 탐험을 시작한 순간에 한번만 `totalDistance`를 계산
- 하지만 길을 돌아서 가거나? 등의 경우로 스팟과 처음보다 멀어질 수도 있을 경우를 생각해서 `leftDistance`가 `totalDistance`보다 크면 업데이트 하도록 수정
```swift
if distance > total {
                print("🔁 총 거리 갱신")
                self.totalDistance = distance
            }
```

### QA 반영 및 버전 업데이트
- 리뷰 목록에서 이동시간 단위 m -> 시/분으로 변경
- 언어 설정 한글로 변경
- 버전 `1.0.1`로 업데이트

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/3265af2f-10c3-49b2-8739-41dc76cecd6d" width ="250">|

📟 **관련 이슈**
- Resolved: #112 
