### PR TITLE
[Feat] #81 - 홈뷰 스켈레톤 구현

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/ShimmerModifier.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/ShimmerModifier.swift
@@ -13,25 +13,26 @@ struct ShimmerModifier: ViewModifier {
     @State private var phase: CGFloat = -1
     
     func body(content: Content) -> some View {
-        ZStack {
-            content
-            GeometryReader { proxy in
-                let w = proxy.size.width
-                let h = proxy.size.height
-                
-                LinearGradient(
-                    gradient: Gradient(colors: [
-                        WalkieCommonAsset.gray100.swiftUIColor,
-                        WalkieCommonAsset.gray200.swiftUIColor,
-                        WalkieCommonAsset.gray100.swiftUIColor
-                    ]),
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-                .frame(width: w * 3, height: h)
-                .offset(x: phase * w * 3)
+        content
+            .overlay {
+                GeometryReader { proxy in
+                    let w = proxy.size.width
+                    let h = proxy.size.height
+                    
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            WalkieCommonAsset.gray100.swiftUIColor,
+                            WalkieCommonAsset.gray200.swiftUIColor,
+                            WalkieCommonAsset.gray100.swiftUIColor
+                        ]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: w * 3, height: h)
+                    .offset(x: phase * w * 3)
+                }
+                .mask(content)
             }
-            .mask(content)
             .onAppear {
                 phase = -1
                 withAnimation(
@@ -41,6 +42,5 @@ struct ShimmerModifier: ViewModifier {
                     phase = 1
                 }
             }
-        }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/ShimmerModifier.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/ShimmerModifier.swift
@@ -1,0 +1,46 @@
+//
+//  ShimmerModifier.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 5/14/25.
+//
+
+import SwiftUI
+
+import WalkieCommon
+
+struct ShimmerModifier: ViewModifier {
+    @State private var phase: CGFloat = -1
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            GeometryReader { proxy in
+                let w = proxy.size.width
+                let h = proxy.size.height
+                
+                LinearGradient(
+                    gradient: Gradient(colors: [
+                        WalkieCommonAsset.gray100.swiftUIColor,
+                        WalkieCommonAsset.gray200.swiftUIColor,
+                        WalkieCommonAsset.gray100.swiftUIColor
+                    ]),
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: w * 3, height: h)
+                .offset(x: phase * w * 3)
+            }
+            .mask(content)
+            .onAppear {
+                phase = -1
+                withAnimation(
+                    .linear(duration: 1.5)
+                    .repeatForever(autoreverses: false)
+                ) {
+                    phase = 1
+                }
+            }
+        }
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/SkeletonModifier.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/SkeletonModifier.swift
@@ -1,0 +1,17 @@
+//
+//  SkeletonModifier.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 5/14/25.
+//
+
+import SwiftUI
+
+struct SkeletonModifier: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        content
+            .redacted(reason: .placeholder)
+            .shimmer()
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/View+.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/View+.swift
@@ -115,4 +115,12 @@ extension View {
                 .interactiveDismissDisabled(true)
         }
     }
+    
+    func shimmer() -> some View {
+        modifier(ShimmerModifier())
+    }
+    
+    func skeleton() -> some View {
+        modifier(SkeletonModifier())
+    }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/SkeletonRectangle/SkeletonRect.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/SkeletonRectangle/SkeletonRect.swift
@@ -1,0 +1,35 @@
+//
+//  SkeletonRect.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 5/14/25.
+//
+
+import SwiftUI
+
+import WalkieCommon
+
+struct SkeletonRect: View {
+    
+    let isGray100: Bool = true
+    let width: CGFloat
+    let height: CGFloat
+    let cornerRadius: CGFloat
+    
+    var body: some View {
+        Rectangle()
+            .fill(
+                isGray100
+                ? WalkieCommonAsset.gray100.swiftUIColor
+                : WalkieCommonAsset.gray200.swiftUIColor)
+            .frame(
+                width: width,
+                height: height
+            )
+            .cornerRadius(
+                cornerRadius,
+                corners: .allCorners
+            )
+            .skeleton()
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeSkeletonView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeSkeletonView.swift
@@ -1,0 +1,74 @@
+//
+//  HomeStatsSkeletonView.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 5/14/25.
+//
+
+import SwiftUI
+
+import WalkieCommon
+
+struct HomeStatsSkeletonView: View {
+    
+    @Environment(\.screenWidth) var screenWidth
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            SkeletonRect(
+                width: screenWidth - 34,
+                height: 371,
+                cornerRadius: 20
+            )
+            
+            SkeletonRect(
+                width: screenWidth - 34,
+                height: 52,
+                cornerRadius: 12
+            )
+        }
+    }
+}
+
+struct HomeHistorySkeletonView: View {
+    
+    @Environment(\.screenWidth) var screenWidth
+    
+    private let columns = [GridItem(.flexible())]
+    
+    var body: some View {
+        VStack(
+            alignment: .leading,
+            spacing: 8
+        ) {
+            SkeletonRect(
+                width: 109,
+                height: 20,
+                cornerRadius: 8
+            )
+            
+            LazyHGrid(
+                rows: columns,
+                spacing: 8
+            ) {
+                ForEach(0..<3, id: \.self) { _ in
+                    VStack {
+                        SkeletonRect(
+                            width: (screenWidth - 48) / 3,
+                            height: 70,
+                            cornerRadius: 12
+                        )
+                        
+                        SkeletonRect(
+                            width: (screenWidth - 48) / 3,
+                            height: 20,
+                            cornerRadius: 8
+                        )
+                    }
+                }
+            }
+        }
+        .padding(.top, 23)
+        .padding(.horizontal, 16)
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -62,7 +62,7 @@ struct HomeView: View {
                                     }
                                 )
                             default:
-                                ProgressView()
+                                HomeStatsSkeletonView()
                             }
                         }
                         .padding(.top, 8)
@@ -73,7 +73,7 @@ struct HomeView: View {
                         HomeHistoryView(homeState: homeHistoryState)
                             .padding(.top, 18)
                     default:
-                        ProgressView()
+                        HomeHistorySkeletonView()
                     }
                 }
             }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
 ### 스켈레톤 `modifier` 구현
- `redacted`와 `shimmer`를 통한 스켈레톤 구현
```swift

struct SkeletonModifier: ViewModifier {
    func body(content: Content) -> some View {
        content
            .redacted(reason: .placeholder)
            .shimmer()
    }
}

// View +
func shimmer() -> some View {
    modifier(ShimmerModifier())
}
    
func skeleton() -> some View {
    modifier(SkeletonModifier())
}
```
- `radius` 있는 사각형이 대부분이라 `SkeletonRect`로 따로 뺐습니다.
```swift
struct SkeletonRect: View {
    let isGray100: Bool = true
    let width: CGFloat
    let height: CGFloat
    let cornerRadius: CGFloat
}
```
- 스켈레톤을 붙일 컴포넌트에 `modifier`를 붙여주시면 됩니다!(SkeletonRect에는 이미 포함)
```swift
Rectangle()
    .fill(WalkieCommonAsset.gray100.swiftUIColor)
    .frame(width: width, height: height)
    .cornerRadius(cornerRadius, corners: .allCorners)
    .skeleton()
```

🚨 **참고사항**
- 영상은 일부러 딜레이 넣어서 찍었지만, 실제 코드에는 서버 값 넘어오기 전 `viewmodel.state`가 `loaded`가 아닐때 보이도록 구현했습니다!

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/bd1f51d4-8e4b-49e4-8a31-dbde82057910" width ="250">|

📟 **관련 이슈**
- Resolved: #81 
