### PR TITLE
[Fix] #116 - 알 부화 로직 / UI 레이아웃 수정 / 기타 버그 픽스

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/PushNotificationManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/PushNotificationManager.swift
@@ -9,7 +9,7 @@ final class NotificationManager {
     static let shared = NotificationManager()
     
     @UserDefaultsWrapper<Bool>(key: "notifyEggHatch") private var notifyEggHatch
-    @UserDefaultsWrapper<Bool>(key: "notified") private var notified
+    @UserDefaultsWrapper<Bool>(key: "notified") var notified
     
     init() {
         /// 초깃값 설정
@@ -78,6 +78,7 @@ final class NotificationManager {
                                 print("SUCCESS: Notification scheduled with identifier \(identifier)")
                             }
                         }
+                        self.notified = true
                     }
                 }
             }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/StepManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/StepManager.swift
@@ -75,6 +75,10 @@ final class StepManager {
         }
     }
     
+    func changeEggPlaying(egg: EggEntity) {
+        self.eggEntity = egg
+    }
+    
     // MARK: - Task Execution
     
     func executeForegroundTasks() {
@@ -82,8 +86,9 @@ final class StepManager {
             // 부화 조건 확인 후 이벤트 발생
             if self?.checkStepUseCase.execute() == true {
                 self?.hatchEventSubject.send(())
+            } else {
+                self?.updateForeground()
             }
-            self?.updateForeground()
         }
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -8,6 +8,7 @@ struct WalkieIOSApp: App {
     
     init() {
         _ = StepManager.shared
+        NotificationManager.shared.clearBadge()
         let kakaoNativeAppKey = (Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String) ?? ""
         KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -18,9 +18,26 @@ struct WalkieIOSApp: App {
             ZStack {
                 appCoordinator.buildScene(appCoordinator.currentScene)
                     .environmentObject(appCoordinator)
-                appCoordinator.buildScene(.hatchEgg)
-                    .environmentObject(appCoordinator)
+                    .fullScreenCover(
+                        item: Binding(
+                            get: { appCoordinator.appFullScreenCover },
+                            set: { appCoordinator.appFullScreenCover = $0 }
+                        ),
+                        onDismiss: {
+                            if let onDismiss = appCoordinator.fullScreenCoverOnDismiss {
+                                onDismiss()
+                                appCoordinator.fullScreenCoverOnDismiss = nil
+                            }
+                        }
+                    ) { fullScreenCover in
+                        appCoordinator.buildFullScreenCover(fullScreenCover)
+                            .environmentObject(appCoordinator)
+                            .ignoresSafeArea(.all)
+                            .presentationBackground(.black.opacity(0))
+                    }
+                    .transaction { $0.disablesAnimations = true }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Egg/DefaultEggUseCase.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Egg/DefaultEggUseCase.swift
@@ -41,6 +41,8 @@ extension DefaultEggUseCase: EggUseCase {
                 UserManager.shared.setStepCount(entity.nowStep)
                 // 캐시 초기화
                 self.stepStore.resetStepCountCache()
+                // 걸음 수 업데이트 대상 알 변경
+                StepManager.shared.changeEggPlaying(egg: entity)
             })
             .eraseToAnyPublisher()
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Egg/Implementation/DefaultUpdateEggStepUseCase.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Egg/Implementation/DefaultUpdateEggStepUseCase.swift
@@ -20,6 +20,11 @@ final class DefaultUpdateEggStepUseCase: BaseEggUseCase, UpdateEggStepUseCase {
                     switch completion {
                     case .finished:
                         print("걸음 수 업데이트 성공!")
+                        if willHatch {
+                            // 초기화
+                            UserManager.shared.setStepCountGoal(.max)
+                            NotificationManager.shared.notified = false
+                        }
                     case .failure(let error):
                         print("걸음 수 업데이트 오류: \(error)")
                     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Step/Implementation/DefaultCheckStepUseCase.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Step/Implementation/DefaultCheckStepUseCase.swift
@@ -9,6 +9,9 @@ import UIKit
 
 final class DefaultCheckStepUseCase: BaseStepUseCase, CheckStepUseCase {
     func execute() -> Bool {
+        print("UserManager.shared.getStepCountGoal: \(UserManager.shared.getStepCountGoal)")
+        print("UserManager.shared.getStepCount: \(UserManager.shared.getStepCount)")
+        print("stepStore.getStepCountCache(): \(stepStore.getStepCountCache())")
         if UserManager.shared.getStepCountGoal
             <= UserManager.shared.getStepCount
             + stepStore.getStepCountCache() {
@@ -16,8 +19,10 @@ final class DefaultCheckStepUseCase: BaseStepUseCase, CheckStepUseCase {
                 title: "알이 부화하려고 해요!",
                 body: "어서 가서 깨워주세요"
             )
+            print("hatch true")
             return true
         }
+        print("hatch false")
         return false
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
@@ -45,8 +45,8 @@ struct TabBarView: View {
                     case .map:
                         EmptyView()
                     }
-                    
                     VStack(spacing: 0) {
+                        Spacer(minLength: 0)
                         ZStack(alignment: .bottom) {
                             Rectangle()
                                 .fill(WalkieCommonAsset.gray50.swiftUIColor)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
@@ -12,21 +12,25 @@ import WalkieCommon
 struct HatchEggView: View {
     
     @ObservedObject var hatchEggViewModel: HatchEggViewModel
+    @EnvironmentObject var appCoordinator: AppCoordinator
     
     var body: some View {
         ZStack(alignment: .center) {
             Color(white: 0, opacity: 0.6)
+                .ignoresSafeArea()
                 .onTapGesture {
                     if hatchEggViewModel.animationState.isShowingGlowEffect {
-                        hatchEggViewModel.action(.willDismiss)
+                        appCoordinator.dismissFullScreenCover()
                     }
                 }
             switch hatchEggViewModel.state {
             case .loaded(let hatchState):
-                WalkieLottieView(
-                    lottie: WalkieLottie.confetti,
-                    isPlaying: hatchEggViewModel.animationState.isPlayingConfetti
-                )
+                if hatchEggViewModel.animationState.isPlayingConfetti {
+                    WalkieLottieView(
+                        lottie: WalkieLottie.confetti,
+                        isPlaying: hatchEggViewModel.animationState.isPlayingConfetti
+                    )
+                }
                 Image(.glowEffect)
                     .resizable()
                     .frame(width: 520, height: 372)
@@ -79,7 +83,6 @@ struct HatchEggView: View {
                 .alignmentGuide(VerticalAlignment.center) { view in
                     view[.bottom] + 132
                 }
-                
                 VStack(alignment: .center, spacing: 0) {
                     let characterName = switch hatchState.characterType {
                     case .jellyfish:
@@ -107,7 +110,6 @@ struct HatchEggView: View {
                 ProgressView()
             }
         }
-        .ignoresSafeArea(.all)
         .onAppear { hatchEggViewModel.action(.willAppear)
             scheduleAnimation()
         }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggViewModel.swift
@@ -26,7 +26,6 @@ final class HatchEggViewModel: ViewModelable {
         case willShowConfettiEffectWithVibration // 3.7초
         case willShowcharacter // 3.9초
         case willShowGlowEffect // 4초
-        case willDismiss
     }
     
     enum State {
@@ -76,7 +75,7 @@ final class HatchEggViewModel: ViewModelable {
         switch action {
         case .willAppear:
             getEggPlaying()
-            hatchEgg()
+            //            hatchEgg()
         case .willShowWaitText:
             self.animationState = .init(
                 isShowingWaitText: true,
@@ -143,12 +142,10 @@ final class HatchEggViewModel: ViewModelable {
                 isShowingEggHatchText: false,
                 isShowingEggLottie: false,
                 isPlayingEggLottie: false,
-                isPlayingConfetti: true,
+                isPlayingConfetti: false,
                 isShowingCharacter: true,
                 isShowingGlowEffect: true
             )
-        case .willDismiss:
-            self.appCoordinator.isPresentingHatchView = false
         }
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggViewModel.swift
@@ -75,7 +75,6 @@ final class HatchEggViewModel: ViewModelable {
         switch action {
         case .willAppear:
             getEggPlaying()
-            //            hatchEgg()
         case .willShowWaitText:
             self.animationState = .init(
                 isShowingWaitText: true,
@@ -155,10 +154,6 @@ final class HatchEggViewModel: ViewModelable {
                 with: self,
                 receiveValue: { _, data in
                     self.hatchEggState = data
-                    guard let data = self.hatchEggState else {
-                        print(" --- 알 정보 불러오기 실패 --- ")
-                        return
-                    }
                     self.state = .loaded(
                         HatchEggState(
                             eggType: data.eggType,
@@ -167,6 +162,7 @@ final class HatchEggViewModel: ViewModelable {
                             dinoType: data.dinoType ?? .defaultDino
                         )
                     )
+                    self.hatchEgg()
                 }, receiveFailure: { _, error in
                     let errorMessage = error?.description ?? "An unknown error occurred"
                     self.state = .error(errorMessage)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -163,7 +163,6 @@ struct HomeView: View {
                     },
                     checkButtonTitle: "허용하기"
                 )
-                appCoordinator.showAlert()
             }
         }
         .permissionBottomSheet(

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct HomeView: View {
     
-    @Environment(\.scenePhase) var scenePhase
-    
     @ObservedObject var viewModel: HomeViewModel
     @Environment(\.screenWidth) var screenWidth
     @Environment(\.screenHeight) var screenHeight
@@ -20,8 +18,6 @@ struct HomeView: View {
     @State private var showMotionBS: Bool = false
     @State private var showAlarmBS: Bool = false
     @State private var showBS: Bool = false
-    
-    @State private var timer: Timer?
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
     
@@ -86,34 +82,6 @@ struct HomeView: View {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     handlePermissionBS()
                 }
-            }
-            
-            // 포그라운드에서 Timer 시작
-            if timer == nil && scenePhase == .active {
-                startTimer()
-            }
-        }
-        .onDisappear {
-            // 뷰가 사라질 때 Timer 정리
-            stopTimer()
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            switch newPhase {
-            case .background:
-                print("---background---")
-                // 백그라운드 작업 실행
-                StepManager.shared.executeBackgroundTasks()
-                stopTimer() // 포그라운드 Timer 중지
-            case .inactive:
-                print("---inactive---")
-                stopTimer() // 비활성 상태에서 Timer 중지
-            case .active:
-                print("---active---")
-                if timer == nil {
-                    startTimer() // 포그라운드에서 Timer 재시작
-                }
-            @unknown default:
-                fatalError()
             }
         }
         .onChange(of: viewModel.state) { _, newState in
@@ -183,20 +151,6 @@ struct HomeView: View {
                 DIContainer.shared.buildAlarmListView()
                     .navigationBarBackButtonHidden()
             }
-    }
-    
-    private func startTimer() {
-        // 포그라운드에서 10초 간격으로 서버 업데이트
-        timer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { _ in
-            StepManager.shared.executeForegroundTasks()
-            print("포그라운드: 서버에 업데이트 완료")
-        }
-    }
-    
-    private func stopTimer() {
-        // Timer 해제
-        timer?.invalidate()
-        timer = nil
     }
     
     private func handlePermissionBS() {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainAccountActionButtonsView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainAccountActionButtonsView.swift
@@ -30,7 +30,6 @@ struct MypageMainAccountActionButtonsView: View {
                     checkButtonTitle: "로그아웃",
                     cancelButtonTitle: "뒤로가기"
                 )
-                appCoordinator.showAlert()
             }, label: {
                 Text("로그아웃")
                     .font(.B2)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -14,7 +14,6 @@ enum AppScene: AppRoute {
     case complete
     case login
     
-    case hatchEgg
     
     case tabBar
     
@@ -22,8 +21,6 @@ enum AppScene: AppRoute {
         switch self {
         case .splash:
             return "splash"
-        case .hatchEgg:
-            return "hatchEgg"
         case .nickname:
             return "nickname"
         case .complete:
@@ -61,20 +58,33 @@ enum AppSheet: AppRoute {
     }
 }
 
-enum AppFullScreenCover: AppRoute {
-    case none
+enum AppFullScreenCover: AppRoute, Identifiable, Hashable {
+    case hatchEgg
+    case alert(
+        title: String,
+        content: String,
+        style: ModalStyleType,
+        button: ModalButtonType,
+        cancelAction: () -> Void,
+        checkAction: () -> Void,
+        checkTitle: String,
+        cancelTitle: String
+    )
     
     var id: String {
         switch self {
-        case .none:
-            return "none"
+        case .hatchEgg:
+            return "hatchEgg"
+        case .alert(let title, _, _, _, _, _, _, _):
+            return "alert_\(title)"
         }
     }
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    
+    static func == (lhs: AppFullScreenCover, rhs: AppFullScreenCover) -> Bool {
         lhs.id == rhs.id
     }
+    
     func hash(into hasher: inout Hasher) {
-        id.hash(into: &hasher)
+        hasher.combine(id)
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

### 알 변경 시 `StepManager`에 반영
`PassThroughSubject` 사용하여 StepManager가 이벤트 감지하도록 하였습니다.
이전에 알 변경 시에 걸음 수 업데이트가 변경된 알로 되지 않는 문제를 해결하였습니다.

### 알림 뱃지 초기화 로직 추가
왜 없어졌는지 모르겠네요?? 다시 추가했습니다

### 탭바 초기 로딩 시 레이아웃 버그 수정
기존에 마이페이지 초기 로딩 시 마이페이지에 `ProgressView`가 뜨는 동안 탭바가 잠깐 위로 가는 버그가 있었습니다.
탭바 VStack에 Spacer 넣어서 항상 아래에 고정되어있도록 했습니다.

### 알 부화 뷰 레이아웃 버그 수정
`ZStack`으로 묶었더니 아래에 놓인 홈뷰 레이아웃이 퍼지는 현상이 있었습니다
이유는 아직도 모르겠습니다...
그래서 `AppCoordinator` 통해서 `.fullScreenCover`로 알럿뷰랑 통합하여 로직을 구현하였습니다

### 알 부화 API 요청 버그 수정
- 호출 시점이 잘못되어 알 정보가 아직 없을 때 요청하도록 되어있었어서 수정했습니다
- 이후 알 부화 알림이 계속 올 수 있었으나 notified 플래그와 걸음 수 목표값 초기화를 통해 1번만 오도록 하였습니다

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->

### 알럿 뷰 / 알 부화 뷰의 DimView opacity transition 안 되는 문제
`.fullScreenCover`가 가진 기본적인 모달 팝업 애니메이션을 삭제해야했는데,
```swift
.transaction { $0.disablesAnimations = true }
```
위 코드를 사용하니 다른 애니메이션도 함께 없어지네요..
```swift
.transaction { $0.animation = nil }
```
이거도 해봤는데 역시 똑같아서,, 일단 합친 다음 다른 브랜치에서 해결하고 올리도록 하겠습니다


📸 **스크린샷**

📟 **관련 이슈**
- Resolved: #116 
