### PR TITLE
[Feat] #125 - 회원탈퇴 후 재가입 시도 시 모달 구현

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -103,7 +103,16 @@ final class AppCoordinator: Coordinator, ObservableObject {
         switch fullScreenCover {
         case .hatchEgg:
             diContainer.buildHatchEggView()
-        case .alert(let title, let content, let style, let button, let cancelAction, let checkAction, let checkTitle, let cancelTitle):
+        case .alert(
+            let title,
+            let content,
+            let style,
+            let button,
+            let cancelAction,
+            let checkAction,
+            let checkTitle,
+            let cancelTitle
+        ):
             ZStack {
                 Color.black.opacity(appFullScreenCover != nil ? 0.6 : 0.0)
                     .ignoresSafeArea()

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/Modal/Modal.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/Modal/Modal.swift
@@ -42,12 +42,14 @@ struct Modal: View {
             Text(title)
                 .font(.H4)
                 .foregroundColor(WalkieCommonAsset.gray700.swiftUIColor)
+                .padding(.horizontal, 16)
                 .padding(.bottom, 4)
             
             Text(content)
                 .font(.B2)
                 .foregroundColor(WalkieCommonAsset.gray500.swiftUIColor)
-                .padding(.bottom, 20)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 20)   
                 .multilineTextAlignment(
                     content.contains("백그라운드 동작") ? .leading : .center
                 )

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Enums/MypageItemEnum.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Enums/MypageItemEnum.swift
@@ -113,11 +113,11 @@ enum MypageServiceSectionItem: MypageSectionItem {
     func destinationView(viewModel: MypageMainViewModel) -> some View {
         switch self {
         case .notice:
-            MypageNotionWebView(url: MypageNotionWebViewURL.notice.url)
+            MypageWebView(url: MypageNotionWebViewURL.notice.url)
         case .privacyPolicy:
-            MypageNotionWebView(url: MypageNotionWebViewURL.privacy.url)
+            MypageWebView(url: MypageNotionWebViewURL.privacy.url)
         case .servicePolicy:
-            MypageNotionWebView(url: MypageNotionWebViewURL.service.url)
+            MypageWebView(url: MypageNotionWebViewURL.service.url)
         case .appVersion:
             EmptyView()
         }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainFeedbackButtonView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainFeedbackButtonView.swift
@@ -13,7 +13,7 @@ struct MypageMainFeedbackButtonView: View {
     var body: some View {
         NavigationLink(
             destination:
-                MypageNotionWebView(url: MypageNotionWebViewURL.questions.url)
+                MypageWebView(url: MypageNotionWebViewURL.questions.url)
                 .navigationBarBackButtonHidden()
         ) {
             HStack(spacing: 0) {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageWebView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageWebView.swift
@@ -1,0 +1,24 @@
+//
+//  MypageWebView.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 5/16/25.
+//
+
+import SwiftUI
+
+struct MypageWebView: View {
+    
+    let url: URL?
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            NavigationBar(
+                showBackButton: true
+            )
+            
+            MypageNotionWebView(url: url)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/ViewModel/MypageMainViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/ViewModel/MypageMainViewModel.swift
@@ -14,10 +14,6 @@ final class MypageMainViewModel: ViewModelable {
     private let patchProfileUseCase: PatchProfileUseCase
     private let getProfileUseCase: GetProfileUseCase
     private let withdrawUseCase: WithdrawUseCase
-//    @EnvironmentObject private var appCoordinator: AppCoordinator
-    
-    var hasFetchedInitialData = false
-    
     private var cancellables = Set<AnyCancellable>()
     
     enum MypageMainViewState {
@@ -64,10 +60,7 @@ final class MypageMainViewModel: ViewModelable {
     func action(_ action: Action) {
         switch action {
         case .mypageMainWillAppear:
-            if !hasFetchedInitialData {
-                fetchMypageMainData()
-                hasFetchedInitialData = true
-            }
+            fetchMypageMainData()
         case .toggleMyInformationIsPublic:
             updateMyInformationPublicSetting()
         case .toggleNotifyEggHatches:

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/ViewModel/MypageMainViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/ViewModel/MypageMainViewModel.swift
@@ -14,7 +14,7 @@ final class MypageMainViewModel: ViewModelable {
     private let patchProfileUseCase: PatchProfileUseCase
     private let getProfileUseCase: GetProfileUseCase
     private let withdrawUseCase: WithdrawUseCase
-    @EnvironmentObject private var appCoordinator: AppCoordinator
+//    @EnvironmentObject private var appCoordinator: AppCoordinator
     
     var hasFetchedInitialData = false
     
@@ -149,7 +149,10 @@ final class MypageMainViewModel: ViewModelable {
             .walkieSink(
                 with: self,
                 receiveValue: { _, _ in
-                    self.appCoordinator.changeRoot()
+                    NotificationCenter.default.post(
+                        name: .reissueFailed,
+                        object: nil
+                    )
                 }, receiveFailure: { _, error  in
                     let errorMessage = error?.description ?? "An unknown error occurred"
                     self.state = .error(errorMessage)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
@@ -97,6 +97,24 @@ struct LoginView: View {
                 appCoordinator.loginInfo = loginViewModel.loginInfo
                 UserManager.shared.setUserNickname(loginViewModel.loginInfo.username)
                 appCoordinator.currentScene = loginState.isExistMember ? .tabBar : .nickname
+            case .error(retrySign: let retrySign):
+                if retrySign {
+                    appCoordinator.presentFullScreenCover(
+                        AppFullScreenCover
+                            .alert(
+                                title: "로그인 실패",
+                                content: "실패했숴 ㅋ",
+                                style: .error,
+                                button: .onebutton,
+                                cancelAction: {},
+                                checkAction: {},
+                                checkTitle: "확인",
+                                cancelTitle: ""),
+                        onDismiss: {
+                            loginViewModel.state = .loading
+                        }
+                    )
+                }
             default:
                 break
             }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
@@ -102,8 +102,8 @@ struct LoginView: View {
                     appCoordinator.presentFullScreenCover(
                         AppFullScreenCover
                             .alert(
-                                title: "로그인 실패",
-                                content: "실패했숴 ㅋ",
+                                title: "탈퇴 처리된 계정",
+                                content: "해당 아이디는 탈퇴 처리된 계정입니다. 자세한 사항은 이메일로 문의해 주시면 안내해 드리겠습니다. \n📧 이메일: walkieofficial@gmail.com",
                                 style: .error,
                                 button: .onebutton,
                                 cancelAction: {},

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginViewModel.swift
@@ -35,7 +35,7 @@ final class LoginViewModel: NSObject, ViewModelable {
     enum LoginViewState: Equatable {
         case loading
         case loaded(LoginState)
-        case error
+        case error(retrySign: Bool)
     }
     
     @Published var state: LoginViewState = .loading
@@ -134,8 +134,15 @@ extension LoginViewModel {
                     } catch {
                         
                     }
-                }, receiveFailure: { _, _ in
-                    self.state = .error
+                }, receiveFailure: { _, error in
+                    if let netErr = error {
+                        switch netErr {
+                        case .unauthorizedError: // 탈퇴후재가입시도
+                            self.state = .error(retrySign: true)
+                        default:
+                            self.state = .error(retrySign: false)
+                        }
+                    }
                 }
             )
             .store(in: &self.cancellables)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -14,7 +14,6 @@ enum AppScene: AppRoute {
     case complete
     case login
     
-    
     case tabBar
     
     var id: String {


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 회원탈퇴 후 재가입 시도 시 모달 구현
- 해당 경우에 서버에서 401을 내려주기 때문에 해당 케이스를 뷰모델에서 예외처리 했습니다.
```swift
 receiveFailure: { _, error in
                    if let netErr = error {
                        switch netErr {
                        case .unauthorizedError: // 탈퇴후재가입시도
                            self.state = .error(retrySign: true)
                        default:
                            self.state = .error(retrySign: false)
                        }
                    }
```
- 뷰에서는 `retrySign`이 `true`로 넘어왔을때만 모달을 띄워주고 `dismiss`될때는 `state` 초기화해주었습니다. 
- 초기화를 해준 이유는 만약에 두 계정 모두 해당 케이스일때 `onChange`에서 동일 `state`로 인식을 못해서 `default`로 빠지는 경우가 생기기 때문입니다!
```swift
case .error(retrySign: let retrySign):
                if retrySign {
                    appCoordinator.presentFullScreenCover(
                        AppFullScreenCover
                            .alert(),
                        onDismiss: {
                            loginViewModel.state = .loading
                        }
                    )
                }
```

### 웹뷰 네비바 백버튼 추가
- QA에서 반영한거 같은데 코드가 사라져있어서,, 다시 넣어놨습니다!
- `MypageWebView` 안에 `NavigationBar`와 `MypageNotionWebView`를 넣어서 그 뷰를 보여주도록 수정했습니다.
```swift
MypageWebView(url: MypageNotionWebViewURL.notice.url)
```

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/40b9bff0-83e0-4f4f-8da4-2bdfe4bbe4a6" width ="250">|

📟 **관련 이슈**
- Resolved: #125 
