### PR TITLE
[Refactor] #137 - 팩토리 메소드 패턴 및 StateObject 도입으로 싱글톤 구조 개선

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -27,13 +27,34 @@ final class DIContainer {
     private lazy var authRepo = DefaultAuthRepository(authService: authService)
     
     private lazy var stepStore = DefaultStepStore()
+}
+
+// UseCases
+
+extension DIContainer {
     
-    // Singleton ViewModels
-    private lazy var homeViewModel: HomeViewModel = {
-        HomeViewModel(
-            getEggPlayUseCase: DefaultGetEggPlayUseCase(
-                memberRepository: memberRepo
-            ),
+    func resolveCheckStepUseCase() -> CheckStepUseCase {
+        return DefaultCheckStepUseCase(stepStore: stepStore)
+    }
+    func resolveUpdateStepCacheUseCase() -> UpdateStepCacheUseCase {
+        return DefaultUpdateStepCacheUseCase(stepStore: stepStore)
+    }
+    func resolveUpdateEggStepUseCase() -> UpdateEggStepUseCase {
+        return DefaultUpdateEggStepUseCase(eggRepository: eggRepo)
+    }
+    
+    func resolveGetEggPlayUseCase() -> GetEggPlayUseCase {
+        return DefaultGetEggPlayUseCase(memberRepository: memberRepo)
+    }
+}
+
+// ViewModels
+
+extension DIContainer {
+    
+    func makeHomeViewModel() -> HomeViewModel {
+        return HomeViewModel(
+            getEggPlayUseCase: resolveGetEggPlayUseCase(),
             getCharacterPlayUseCase: DefaultGetWalkingCharacterUseCase(
                 memberRepository: memberRepo
             ),
@@ -47,16 +68,25 @@ final class DIContainer {
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var mapViewModel: MapViewModel = {
-        MapViewModel(
+    }
+    
+    func makeMapViewModel() -> MapViewModel {
+        return MapViewModel(
             getCharacterPlayUseCase: DefaultGetCharacterPlayUseCase(
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var mypageMainViewModel: MypageMainViewModel = {
-        MypageMainViewModel(
+    }
+    
+    func makeReviewViewModel() -> ReviewViewModel {
+        return ReviewViewModel(
+            reviewUseCase: DefaultReviewUseCase(reviewRepository: reviewRepo),
+            delReviewUseCase: DefaultDeleteReviewUseCase(reviewRepository: reviewRepo)
+        )
+    }
+    
+    func makeMypageMainViewModel() -> MypageMainViewModel {
+        return MypageMainViewModel(
             logoutUseCase: DefaultLogoutUserUseCase(
                 authRepository: authRepo,
                 memberRepository: memberRepo
@@ -71,29 +101,23 @@ final class DIContainer {
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var eggViewModel: EggViewModel = {
-        EggViewModel(
+    }
+    
+    func makeCalendarViewModel(using reviewVM: ReviewViewModel) -> CalendarViewModel {
+        return CalendarViewModel(reviewViewModel: reviewVM)
+    }
+    
+    func makeEggViewModel() -> EggViewModel {
+        return EggViewModel(
             eggUseCase: DefaultEggUseCase(
                 eggRepository: eggRepo,
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var alarmListViewModel: AlarmListViewModel = {
-        AlarmListViewModel()
-    }()
-    private lazy var reviewViewModel: ReviewViewModel = {
-        ReviewViewModel(
-            reviewUseCase: DefaultReviewUseCase(
-                reviewRepository: reviewRepo
-            ), delReviewUseCase: DefaultDeleteReviewUseCase(
-                reviewRepository: reviewRepo
-            )
-        )
-    }()
-    private lazy var characterViewModel: CharacterViewModel = {
-        CharacterViewModel(
+    }
+    
+    func makeCharacterViewModel() -> CharacterViewModel {
+        return CharacterViewModel(
             getCharactersListUseCase: DefaultGetCharactersListUseCase(
                 characterRepository: characterRepo
             ),
@@ -104,92 +128,108 @@ final class DIContainer {
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var loginViewModel: LoginViewModel = {
-        LoginViewModel(
+    }
+    
+    func makeLoginViewModel() -> LoginViewModel {
+        return LoginViewModel(
             loginUseCase: DefaultLoginUseCase(
                 authRepository: authRepo,
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var signupViewModel: SignupViewModel = {
-        SignupViewModel(
+    }
+    
+    func makeSignupViewModel() -> SignupViewModel {
+        return SignupViewModel(
             signupUseCase: DefaultSignupUseCase(
                 authRepository: authRepo,
                 memberRepository: memberRepo
             )
         )
-    }()
-    private lazy var hatchEggViewModel: HatchEggViewModel = {
-        HatchEggViewModel(
-            getEggPlayUseCase: DefaultGetEggPlayUseCase(
-                memberRepository: memberRepo
-            ),
+    }
+    
+    func makeHatchEggViewModel() -> HatchEggViewModel {
+        return HatchEggViewModel(
+            getEggPlayUseCase: resolveGetEggPlayUseCase(),
             updateEggStepUseCase: DefaultUpdateEggStepUseCase(
                 eggRepository: eggRepo
             )
         )
-    }()
-    private lazy var calendarViewModel: CalendarViewModel = {
-        CalendarViewModel(reviewViewModel: reviewViewModel)
-    }()
+    }
+    
+    func makeAlarmListViewModel() -> AlarmListViewModel {
+        return AlarmListViewModel()
+    }
 }
 
 extension DIContainer {
     
     // MARK: - Main Views
     func buildHomeView() -> HomeView {
-        return HomeView(viewModel: homeViewModel)
-    }
-    func buildMapView() -> MapView {
-        return MapView(viewModel: mapViewModel)
-    }
-    func buildMypageView() -> MypageMainView {
-        return MypageMainView(viewModel: mypageMainViewModel)
-    }
-    func buildEggView() -> EggView {
-        return EggView(viewModel: eggViewModel)
-    }
-    func buildAlarmListView() -> AlarmListView {
-        return AlarmListView(viewModel: alarmListViewModel)
-    }
-    func buildReviewView() -> ReviewView {
-        return ReviewView(
-            viewModel: reviewViewModel,
-            calendarViewModel: calendarViewModel
+        return HomeView(
+            viewModel: self.makeHomeViewModel()
         )
     }
+    
+    func buildMapView() -> MapView {
+        return MapView(
+            viewModel: self.makeMapViewModel()
+        )
+    }
+    
+    func buildMypageView() -> MypageMainView {
+        return MypageMainView(
+            viewModel: self.makeMypageMainViewModel()
+        )
+    }
+    
+    func buildEggView() -> EggView {
+        return EggView(
+            viewModel: self.makeEggViewModel()
+        )
+    }
+    
+    func buildReviewView() -> ReviewView {
+        let reviewVM = makeReviewViewModel()
+        let calendarVM = makeCalendarViewModel(using: reviewVM)
+        return ReviewView(
+            viewModel: reviewVM,
+            calendarViewModel: calendarVM
+        )
+    }
+    
     func buildCharacterView() -> CharacterView {
-        return CharacterView(viewModel: characterViewModel)
+        return CharacterView(
+            viewModel: self.makeCharacterViewModel()
+        )
+    }
+    
+    func buildAlarmListView() -> AlarmListView {
+        return AlarmListView(
+            viewModel: self.makeAlarmListViewModel()
+        )
     }
     
     // MARK: - Onboarding Views
     func buildLoginView() -> LoginView {
-        return LoginView(loginViewModel: loginViewModel)
+        return LoginView(
+            loginViewModel: self.makeLoginViewModel()
+        )
     }
+    
     func buildSignupView() -> OnboardingCompleteView {
         return OnboardingCompleteView()
     }
+    
     func buildNicknameView() -> NicknameView {
-        return NicknameView(signupViewModel: signupViewModel)
+        return NicknameView(
+            signupViewModel: self.makeSignupViewModel()
+        )
     }
+    
     func buildHatchEggView() -> HatchEggView {
-        return HatchEggView(hatchEggViewModel: hatchEggViewModel)
-    }
-    
-    // MARK: - UseCases
-    func resolveCheckStepUseCase() -> CheckStepUseCase {
-        return DefaultCheckStepUseCase(stepStore: stepStore)
-    }
-    func resolveUpdateStepCacheUseCase() -> UpdateStepCacheUseCase {
-        return DefaultUpdateStepCacheUseCase(stepStore: stepStore)
-    }
-    func resolveUpdateEggStepUseCase() -> UpdateEggStepUseCase {
-        return DefaultUpdateEggStepUseCase(eggRepository: eggRepo)
-    }
-    
-    func resolveGetEggPlayUseCase() -> GetEggPlayUseCase {
-        return DefaultGetEggPlayUseCase(memberRepository: memberRepo)
+        return HatchEggView(
+            hatchEggViewModel: self.makeHatchEggViewModel()
+        )
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Character/Views/CharacterView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Character/Views/CharacterView.swift
@@ -65,9 +65,6 @@ struct CharacterView: View {
                     .onAppear {
                         viewModel.action(.willAppear)
                     }
-                    .onDisappear {
-                        viewModel.state = .loading
-                    }
                 }.scrollIndicators(.never)
             }
             .bottomSheet(

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Character/Views/CharacterView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Character/Views/CharacterView.swift
@@ -11,7 +11,7 @@ import WalkieCommon
 struct CharacterView: View {
     @Environment(\.screenHeight) var screenHeight
     
-    @ObservedObject var viewModel: CharacterViewModel
+    @StateObject var viewModel: CharacterViewModel
     @State var isPresentingBottomSheet: Bool = false
     
     var body: some View {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Egg/Views/EggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Egg/Views/EggView.swift
@@ -90,9 +90,6 @@ struct EggView: View {
                     .onAppear {
                         viewModel.action(.willAppear)
                     }
-                    .onDisappear {
-                        viewModel.state = .loading
-                    }
                 }
                 .scrollIndicators(.never)
             }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Egg/Views/EggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Egg/Views/EggView.swift
@@ -15,7 +15,7 @@ struct EggView: View {
         GridItem(.flexible())
     ]
     
-    @ObservedObject var viewModel: EggViewModel
+    @StateObject var viewModel: EggViewModel
     @State var isPresentingGuideView: Bool = false
     @State var isPresentingBottomSheet: Bool = false
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
@@ -82,7 +82,10 @@ struct HatchEggView: View {
                         .foregroundStyle(.white)
                         .padding(.bottom, 4)
                         .opacity(hatchEggViewModel.animationState.isShowingEggHatchText ? 1 : 0)
-                        .animation(.easeIn(duration: 0.3), value: hatchEggViewModel.animationState.isShowingEggHatchText)
+                        .animation(
+                            .easeIn(duration: 0.3),
+                            value: hatchEggViewModel.animationState.isShowingEggHatchText
+                        )
                 }
                 .alignmentGuide(VerticalAlignment.center) { view in
                     view[.bottom] + 132

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
@@ -11,7 +11,7 @@ import WalkieCommon
 
 struct HatchEggView: View {
     
-    @ObservedObject var hatchEggViewModel: HatchEggViewModel
+    @StateObject var hatchEggViewModel: HatchEggViewModel
     @EnvironmentObject var appCoordinator: AppCoordinator
     
     var body: some View {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/AlarmList/AlarmListView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/AlarmList/AlarmListView.swift
@@ -11,7 +11,7 @@ import WalkieCommon
 
 struct AlarmListView: View {
     
-    @ObservedObject var viewModel: AlarmListViewModel
+    @StateObject var viewModel: AlarmListViewModel
     @Environment(\.dismiss) var dismiss
     
     var body: some View {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -21,10 +21,6 @@ struct HomeView: View {
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
     
-//    init(viewModel: HomeViewModel) {
-//           _viewModel = StateObject(wrappedValue: viewModel)
-//       }
-    
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             NavigationBar(

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     
-    @ObservedObject var viewModel: HomeViewModel
+    @StateObject var viewModel: HomeViewModel
     @Environment(\.screenWidth) var screenWidth
     @Environment(\.screenHeight) var screenHeight
     @State var navigateAlarmList: Bool = false
@@ -20,6 +20,10 @@ struct HomeView: View {
     @State private var showBS: Bool = false
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
+    
+//    init(viewModel: HomeViewModel) {
+//           _viewModel = StateObject(wrappedValue: viewModel)
+//       }
     
     var body: some View {
         VStack(alignment: .center, spacing: 0) {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapView.swift
@@ -11,7 +11,7 @@ import WalkieCommon
 
 struct MapView: View {
     
-    @ObservedObject var viewModel: MapViewModel
+    @StateObject var viewModel: MapViewModel
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 struct MypageMainView: View {
     
-    @ObservedObject var viewModel: MypageMainViewModel
+    @StateObject var viewModel: MypageMainViewModel
     
     var body: some View {
         ZStack {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
@@ -16,7 +16,7 @@ struct LoginView: View {
     
     private let onboardingPage = OnboardingPageStruct.makeOnboardingPage()
     @EnvironmentObject private var appCoordinator: AppCoordinator
-    @ObservedObject var loginViewModel: LoginViewModel
+    @StateObject var loginViewModel: LoginViewModel
     
     var body: some View {
         NavigationStack(path: $appCoordinator.path) {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Nickname/NicknameView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Nickname/NicknameView.swift
@@ -15,7 +15,7 @@ struct NicknameView: View {
     @State private var isButtonEnabled: Bool = false
     @State private var inputState: InputState = .default
     @FocusState private var focused: Bool
-    @ObservedObject var signupViewModel: SignupViewModel
+    @StateObject var signupViewModel: SignupViewModel
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/Calendar/CalendarView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/Calendar/CalendarView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import WalkieCommon
 
 struct CalendarView: View {
-    @ObservedObject var viewModel: CalendarViewModel
+    @StateObject var viewModel: CalendarViewModel
     @State private var currentWeekOffset: CGFloat = 0
     
     var body: some View {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
@@ -10,8 +10,8 @@ import WalkieCommon
 
 struct ReviewView: View {
     
-    @ObservedObject var viewModel: ReviewViewModel
-    @ObservedObject var calendarViewModel: CalendarViewModel
+    @StateObject var viewModel: ReviewViewModel
+    @StateObject var calendarViewModel: CalendarViewModel
     @State private var selectedReview: ReviewItemId?
     @State private var showReviewEdit: Bool = false
     @State private var showReviewDelete: Bool = false


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 팩토리 메소드 패턴 도입
- 기존에 싱글톤 뷰모델 + `@ObservedObject` 프로퍼티 사용
- 하지만 뷰에서 사용하는 뷰모델을 전역 공유할 필요가 없기 때문에 이를 개선하고자 팩토리 메소드를 도입하게 되었습니다!
```swift
func makeMapViewModel() -> MapViewModel {
    return MapViewModel(
        getCharacterPlayUseCase: DefaultGetCharacterPlayUseCase(
            memberRepository: memberRepo
        )
    )
}
```

### 뷰모델 프로퍼티 `StateObject`로 변경
- 기존에 문제였던 상황(#101)은 뷰모델 프로퍼티를 `ObservedObject`로 선언했기 때문
- `ObservedObject`를 사용하면 뷰가 살아있어도 계속 새로운 뷰모델이 만들어지면서 리렌더링 되는 이슈가 생겨 이를 `StateObject`로 바꿔 문제점을 해결하였습니다. 즉 뷰가 처음 생성될 때 한번 뷰모델을 만들고 그 뒤로는 같은 인스턴스를 꺼내쓰는 구조!

📟 **관련 이슈**
- Resolved: #137 