### PR TITLE
[Feat] #155 - Remote Config를 활용한 강제업데이트 로직 구현

### DIFF
--- a/Walkie-iOS/Project.swift
+++ b/Walkie-iOS/Project.swift
@@ -84,6 +84,7 @@ let project = Project(
                 .external(name: "FirebaseCore"),
                 .external(name: "FirebaseMessaging"),
                 .external(name: "FirebaseAnalytics"),
+                .external(name: "FirebaseRemoteConfig"),
                 .external(name: "Moya"),
                 .external(name: "CombineMoya"),
                 .external(name: "KakaoSDKAuth"),

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -43,7 +43,6 @@ final class AppCoordinator: Coordinator, ObservableObject {
     
     init(diContainer: DIContainer) {
         self.diContainer = diContainer
-        startSplash()
         initializeStepCoordinator()
         NotificationCenter.default
             .publisher(for: .reissueFailed)
@@ -62,7 +61,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
     func buildScene(_ scene: AppScene) -> some View {
         switch scene {
         case .splash:
-            SplashView()
+            diContainer.buildSplashView(appCoordinator: self)
         case .nickname:
             diContainer.buildNicknameView()
         case .login:
@@ -114,14 +113,17 @@ final class AppCoordinator: Coordinator, ObservableObject {
             let cancelAction,
             let checkAction,
             let checkTitle,
-            let cancelTitle
+            let cancelTitle,
+            let tapDismiss
         ):
             ZStack {
                 Color.black.opacity(appFullScreenCover != nil ? 0.6 : 0.0)
                     .ignoresSafeArea()
                     .onTapGesture {
                         withAnimation(.easeInOut(duration: 0.25)) {
-                            self.dismissFullScreenCover()
+                            if tapDismiss {
+                                self.dismissFullScreenCover()
+                            }
                         }
                     }
                 Modal(
@@ -134,7 +136,9 @@ final class AppCoordinator: Coordinator, ObservableObject {
                         cancelAction()
                     },
                     checkButtonAction: {
-                        self.dismissFullScreenCover()
+                        if tapDismiss {
+                            self.dismissFullScreenCover()
+                        }
                         checkAction()
                     },
                     checkButtonTitle: checkTitle,
@@ -191,7 +195,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
         }
     }
     
-    private func startSplash() {
+    func startSplash() {
         currentScene = .splash
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
             self?.updateCurrentScene()
@@ -211,7 +215,8 @@ final class AppCoordinator: Coordinator, ObservableObject {
         cancelButtonAction: @escaping () -> Void,
         checkButtonAction: @escaping () -> Void,
         checkButtonTitle: String = "확인",
-        cancelButtonTitle: String = "취소"
+        cancelButtonTitle: String = "취소",
+        tapDismiss: Bool = true
     ) {
         presentFullScreenCover(
             AppFullScreenCover.alert(
@@ -222,7 +227,8 @@ final class AppCoordinator: Coordinator, ObservableObject {
                 cancelAction: cancelButtonAction,
                 checkAction: checkButtonAction,
                 checkTitle: checkButtonTitle,
-                cancelTitle: cancelButtonTitle
+                cancelTitle: cancelButtonTitle,
+                tapDismiss: tapDismiss
             ),
             onDismiss: nil
         )

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -62,6 +62,12 @@ extension DIContainer {
 
 extension DIContainer {
     
+    func makeSplashViewModel(
+        appCoordinator: AppCoordinator
+    ) -> SplashViewModel {
+        return SplashViewModel(appCoordinator: appCoordinator)
+    }
+    
     func makeHomeViewModel(appCoordinator: AppCoordinator) -> HomeViewModel {
         return HomeViewModel(
             getEggPlayUseCase: resolveGetEggPlayUseCase(),
@@ -178,6 +184,16 @@ extension DIContainer {
 }
 
 extension DIContainer {
+    
+    func buildSplashView(
+        appCoordinator: AppCoordinator
+    ) -> SplashView {
+        return SplashView(
+            splashViewModel: self.makeSplashViewModel(
+                appCoordinator: appCoordinator
+            )
+        )
+    }
     
     // MARK: - Main Views
     func buildTabBarView() -> TabBarView {

--- a/Walkie-iOS/Walkie-iOS/Sources/Network/Base/URLConstant.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Network/Base/URLConstant.swift
@@ -13,6 +13,10 @@ enum URLConstant {
     
     static let baseURL = Config.baseURL
     
+    // MARK: - AppStore URL
+    
+    static let appStoreURL = "itms-apps://itunes.apple.com/app/id6742345668"
+    
     // MARK: - URL Path
     
     // auth

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/Modal/Modal.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/Modal/Modal.swift
@@ -44,6 +44,7 @@ struct Modal: View {
                 .foregroundColor(WalkieCommonAsset.gray700.swiftUIColor)
                 .padding(.horizontal, 16)
                 .padding(.bottom, 4)
+                .multilineTextAlignment(.center)
             
             Text(content)
                 .font(.B2)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
@@ -111,7 +111,9 @@ struct LoginView: View {
                                 cancelAction: {},
                                 checkAction: {},
                                 checkTitle: "확인",
-                                cancelTitle: ""),
+                                cancelTitle: "",
+                                tapDismiss: true
+                            ),
                         onDismiss: {
                             loginViewModel.state = .loading
                         }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SplashView: View {
+    
+    @StateObject var splashViewModel: SplashViewModel
         
     var body: some View {
         ZStack {
@@ -17,5 +19,8 @@ struct SplashView: View {
                 .frame(width: 200, height: 200)
         }
         .edgesIgnoringSafeArea(.all)
+        .onAppear {
+            splashViewModel.action(.fetchVersion)
+        }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashViewModel.swift
@@ -1,0 +1,107 @@
+//
+//  SplashViewModel.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 6/4/25.
+//
+
+import SwiftUI
+import Combine
+import FirebaseRemoteConfig
+
+final class SplashViewModel: NSObject, ViewModelable {
+    
+    private let remoteConfig = RemoteConfig.remoteConfig()
+    private let settings = RemoteConfigSettings()
+    private var cancellables = Set<AnyCancellable>()
+    let appCoordinator: AppCoordinator
+    
+    enum Action {
+        case fetchVersion
+    }
+    
+    enum SplashViewState: Equatable {
+        case loading
+        case loaded
+        case error
+    }
+    
+    @Published var state: SplashViewState = .loading
+    
+    init(
+        appCoordinator: AppCoordinator
+    ) {
+        self.appCoordinator = appCoordinator
+        super.init()
+        
+        settings.minimumFetchInterval = 0
+        remoteConfig.configSettings = settings
+        remoteConfig.addOnConfigUpdateListener { [weak self] _, error in
+            if error == nil {
+                Task { await self?.activateRemoteConfig() }
+            }
+        }
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .fetchVersion:
+            Task { await activateRemoteConfig() }
+        }
+    }
+    
+    private func activateRemoteConfig() async {
+        do {
+            try await remoteConfig.fetch()
+            try await remoteConfig.activate()
+            
+            let remoteVersion = remoteConfig["iOS_MIN_APP_VERSION"].stringValue
+            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+            
+            let needsUpdate = isVersion(
+                currentVersion,
+                lowerThan: remoteVersion
+            )
+            if needsUpdate {
+                appCoordinator.buildAlert(
+                    title: "워키를 안전한 버전으로\n업데이트 해주세요.",
+                    content: "여러 사용성과 안전성을 업데이트 했어요.",
+                    style: .primary,
+                    button: .onebutton,
+                    cancelButtonAction: {},
+                    checkButtonAction: {
+                        self.openAppStore()
+                    },
+                    checkButtonTitle: "업데이트",
+                    tapDismiss: false
+                )
+            } else {
+                appCoordinator.startSplash()
+            }
+        } catch {
+            self.state = .error
+        }
+    }
+    
+    private func isVersion(_ v1: String, lowerThan v2: String) -> Bool {
+        let arr1 = v1.split(separator: ".").compactMap { Int($0) }
+        let arr2 = v2.split(separator: ".").compactMap { Int($0) }
+        let maxCount = max(arr1.count, arr2.count)
+        let nums1 = arr1 + Array(repeating: 0, count: maxCount - arr1.count)
+        let nums2 = arr2 + Array(repeating: 0, count: maxCount - arr2.count)
+        
+        for i in 0..<maxCount {
+            if nums1[i] < nums2[i] { return true }
+            if nums1[i] > nums2[i] { return false }
+        }
+        return false
+    }
+    
+    private func openAppStore() {
+        guard let url = URL(string: URLConstant.appStoreURL) else { return }
+        
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -71,14 +71,15 @@ enum AppFullScreenCover: AppRoute, Identifiable, Hashable {
         cancelAction: () -> Void,
         checkAction: () -> Void,
         checkTitle: String,
-        cancelTitle: String
+        cancelTitle: String,
+        tapDismiss: Bool
     )
     
     var id: String {
         switch self {
         case .hatchEgg:
             return "hatchEgg"
-        case .alert(let title, _, _, _, _, _, _, _):
+        case .alert(let title, _, _, _, _, _, _, _, _):
             return "alert_\(title)"
         }
     }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 강제 업데이트 로직 구현
- SplashViewModel에서 remote에서 가져온 버전과 현재 앱 버전을 비교하여 강제업데이트 로직을 수행합니다.
- 강제업데이트가 필요한 appCoordinator에서 buildAlert을, 필요하지 않으면 splash 이후의 플로우를 실행하도록 했습니다.
```swift
if needsUpdate {
    appCoordinator.buildAlert(
        title: "워키를 안전한 버전으로\n업데이트 해주세요.",
        content: "여러 사용성과 안전성을 업데이트 했어요.",
        style: .primary,
        button: .onebutton,
        cancelButtonAction: {},
        checkButtonAction: {
            self.openAppStore()
        },
        checkButtonTitle: "업데이트",
        tapDismiss: false
    )
} else {
    appCoordinator.startSplash()
}
```

### AppCoordinator 수정
- AppFullScreenCover.alert에 tapDismiss를 추가하여 뒤의 백그라운드를 탭했을때 dismiss 여부를 설정하도록 했습니다.
- 강제 업데이트 필요한 경우에는 dismiss가 되면 안되기 때문에 추가하였습니다!
```swift
tapDismiss: Bool = true
```

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/b8da22e2-67c2-4d44-a3ed-9707a90aadf9" width ="250">|

📟 **관련 이슈**
- Resolved: #155 
