### PR TITLE
[Fix] #165 - 토큰 재발급 중복 호출 로직 수정

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -81,10 +81,13 @@ final class AppCoordinator: Coordinator, ObservableObject {
             diContainer.buildSignupView()
         case .egg:
             diContainer.buildEggView(appCoordinator: self)
+                .popGestureEnabled(true)
         case .character:
             diContainer.buildCharacterView()
+                .popGestureEnabled(true)
         case .review:
             diContainer.buildReviewView()
+                .popGestureEnabled(true)
         case let .setting(item, viewModel):
             buildSetting(item, viewModel: viewModel)
         case .service(let item):

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -65,7 +65,13 @@ extension DIContainer {
     func makeSplashViewModel(
         appCoordinator: AppCoordinator
     ) -> SplashViewModel {
-        return SplashViewModel(appCoordinator: appCoordinator)
+        return SplashViewModel(
+            appCoordinator: appCoordinator,
+            getProfileUseCase: DefaultGetProfileUseCase(
+                memberRepository: memberRepo,
+                stepStatusStore: stepStatusStore
+            )
+        )
     }
     
     func makeHomeViewModel(appCoordinator: AppCoordinator) -> HomeViewModel {

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/RefreshTokenManager.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/RefreshTokenManager.swift
@@ -1,0 +1,43 @@
+//
+//  RefreshTokenManager.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 6/9/25.
+//
+
+import Foundation
+import Combine
+import Moya
+
+final class RefreshTokenManager {
+    static let shared = RefreshTokenManager(service: DefaultReissueService())
+    
+    private let service: ReissueService
+    private var refreshPublisher: AnyPublisher<ReissueDto, MoyaError>?
+    private let lock = NSLock()
+    
+    private init(service: ReissueService) {
+        self.service = service
+    }
+    
+    func refresh() -> AnyPublisher<ReissueDto, MoyaError> {
+        lock.lock(); defer { lock.unlock() }
+        if let pub = refreshPublisher { return pub }
+        
+        let token = (try? TokenKeychainManager.shared.getRefreshToken()) ?? ""
+        let pub = service
+            .reissue(refreshToken: token)
+            .mapError { $0 as? MoyaError ?? .underlying($0, nil) }
+            .handleEvents(receiveOutput: { dto in
+                try? TokenKeychainManager.shared.saveAccessToken(dto.accessToken)
+                try? TokenKeychainManager.shared.saveRefreshToken(dto.refreshToken)
+            }, receiveCompletion: { _ in
+                self.lock.lock(); self.refreshPublisher = nil; self.lock.unlock()
+            })
+            .share()
+            .eraseToAnyPublisher()
+        
+        refreshPublisher = pub
+        return pub
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/MoyaProvider+.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/MoyaProvider+.swift
@@ -23,36 +23,9 @@ extension MoyaProvider {
                         .setFailureType(to: MoyaError.self)
                         .eraseToAnyPublisher()
                 case 401:
-                    let token = (try? TokenKeychainManager.shared.getRefreshToken()) ?? ""
-                    print("refresh token: 👌👌\(token)👌👌")
-                    return reissueService
-                        .reissue(refreshToken: token)
-                        .handleEvents(receiveOutput: { dto in
-                            do {
-                                print("✅ 토큰 재저장 시작함")
-                                print(dto)
-                                try TokenKeychainManager.shared.saveAccessToken(dto.accessToken)
-                                try TokenKeychainManager.shared.saveRefreshToken(dto.refreshToken)
-                                print("✅ 토큰 재저장 완료")
-                            } catch {
-                                print("⚠️ 토큰 저장 실패:", error)
-                            }
-                        })
-                        .mapError { moyaError in
-                            moyaError as? MoyaError ?? MoyaError.underlying(moyaError, nil)
-                        }
-                        .handleEvents(receiveCompletion: { completion in
-                            if case .failure = completion {
-                                NotificationCenter.default.post(
-                                    name: .reissueFailed,
-                                    object: nil
-                                )
-                            }
-                        })
-                        .flatMap { _ -> AnyPublisher<Response, MoyaError> in
-                            print("👌👌재발급 완료, 원본 파이프라인으로 재요청👌👌")
-                            return self.requestPublisher(target)
-                        }
+                    return RefreshTokenManager.shared
+                        .refresh()
+                        .flatMap { _ in self.requestPublisher(target) }
                         .eraseToAnyPublisher()
                 default:
                     let error = MoyaError.statusCode(response)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
@@ -88,7 +88,8 @@ struct TabBarView: View {
                 }
             }
             .edgesIgnoringSafeArea(.bottom)
-        }.onAppear {
+        }
+        .onAppear {
             appCoordinator.executeForegroundActions()
         }
     }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### `RefreshTokenManager` 구현
- 기존 문제점은 여러 `api`가 동시에 호출되었는데 토큰이 만료된 경우, 토큰 재발급 로직이 여러 번 호출되고 꼬이면서 로그아웃 처리가 되는 상황이었습니다.
- 동시 호출 방지를 위한 `lock` 개념 사용 및 퍼블리셔 캐싱을 구현하였습니다.
```swift
 func refresh() -> AnyPublisher<ReissueDto, MoyaError> {
    lock.lock(); defer { lock.unlock() }
    if let pub = refreshPublisher { return pub }
        
    let token = (try? TokenKeychainManager.shared.getRefreshToken()) ?? ""
    let pub = service
        .reissue(refreshToken: token)
```
- `requestPublisher`에서는 위의 싱글톤 인스턴스를 사용해서 토큰 재발급을 하도록 수정하였습니다.
```swift
case 401:
    return RefreshTokenManager.shared
        .refresh()
        .flatMap { _ in self.requestPublisher(target) }
        .eraseToAnyPublisher()
```

### 스플래시뷰에서 사용자정보 `api` 호출
- 기존에 토큰 만료 시에 탭바가 잠깐 보였다가 로그인 화면으로 돌아가는 이슈 발생
- 스플래시 뷰모델에서 `api` 호출을 구현해 토큰 재만료 시 더 자연스러운 흐름이 되도록 개선하였습니다.
```swift
private func getProfile() {
    getProfileUseCase.execute()
        .walkieSink(
            with: self,
            receiveValue: { _, _ in
                self.appCoordinator.startSplash()
            }, receiveFailure: { _, error  in
                    print(String(describing: error?.localizedDescription))
            }
    )
    .store(in: &cancellables)
}
```

### 홈에서 파생되는 뷰에 제스처 추가
- 지도뷰 -> 홈 -> 보유한알뷰 이렇게 이동할 때 백제스처가 작동하지 않는 문제점을 발견했습니다.
- 지도뷰에서 `.popGestureEnabled(false)`로 막아서 이후의 뷰에도 영향을 끼치고 있어, 홈에서 파생되는 뷰(`EggView`, `CharacterView`, `ReviewView`)에는 AppCoordinator 쪽에 `.popGestureEnabled(true)`를 붙여주었습니다!
```swift
case .character:
    diContainer.buildCharacterView()
        .popGestureEnabled(true)
```

📟 **관련 이슈**
- Resolved: #165 
