### PR TITLE
[Fix] #169 - 권한바텀시트 애니메이션 사라지는 이슈 해결

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -116,17 +116,14 @@ final class AppCoordinator: Coordinator, ObservableObject {
             let cancelAction,
             let checkAction,
             let checkTitle,
-            let cancelTitle,
-            let tapDismiss
+            let cancelTitle
         ):
             ZStack {
                 Color.black.opacity(appFullScreenCover != nil ? 0.6 : 0.0)
                     .ignoresSafeArea()
                     .onTapGesture {
                         withAnimation(.easeInOut(duration: 0.25)) {
-                            if tapDismiss {
-                                self.dismissFullScreenCover()
-                            }
+                            self.dismissFullScreenCover()
                         }
                     }
                 Modal(
@@ -139,9 +136,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
                         cancelAction()
                     },
                     checkButtonAction: {
-                        if tapDismiss {
-                            self.dismissFullScreenCover()
-                        }
+                        self.dismissFullScreenCover()
                         checkAction()
                     },
                     checkButtonTitle: checkTitle,
@@ -218,8 +213,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
         cancelButtonAction: @escaping () -> Void,
         checkButtonAction: @escaping () -> Void,
         checkButtonTitle: String = "확인",
-        cancelButtonTitle: String = "취소",
-        tapDismiss: Bool = true
+        cancelButtonTitle: String = "취소"
     ) {
         presentFullScreenCover(
             AppFullScreenCover.alert(
@@ -230,8 +224,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
                 cancelAction: cancelButtonAction,
                 checkAction: checkButtonAction,
                 checkTitle: checkButtonTitle,
-                cancelTitle: cancelButtonTitle,
-                tapDismiss: tapDismiss
+                cancelTitle: cancelButtonTitle
             ),
             onDismiss: nil
         )

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -101,6 +101,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
     
     @ViewBuilder
     func buildSheet(_ sheet: AppSheet) -> some View {
+        
     }
     
     @ViewBuilder
@@ -227,6 +228,18 @@ final class AppCoordinator: Coordinator, ObservableObject {
                 cancelTitle: cancelButtonTitle
             ),
             onDismiss: nil
+        )
+    }
+    
+    func buildBottomSheet<Content: View>(
+        height: CGFloat,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        presentSheet(
+            AppSheet.homeAlarm(
+                height: height,
+                content: AnyView(content())
+            )
         )
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/WalkieIOSApp.swift
@@ -44,6 +44,17 @@ struct WalkieIOSApp: App {
                             }
                         )
                         .transaction { $0.disablesAnimations = true }
+                        .permissionBottomSheet(
+                            isPresented: Binding(
+                                get: { appCoordinator.sheet != nil },
+                                set: {
+                                    if !$0 { appCoordinator.dismissSheet() }
+                                }
+                            ),
+                            height: appCoordinator.appSheet?.height ?? 0
+                        ) {
+                            appCoordinator.appSheet?.view
+                        }
                     ToastContainer()
                         .ignoresSafeArea(.all, edges: .bottom)
                         .frame(alignment: .bottom)

--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/EnvironmentValues+.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/EnvironmentValues+.swift
@@ -33,6 +33,18 @@ private struct SafeScreenHeightKey: EnvironmentKey {
     }()
 }
 
+private struct SafeAreaBottomKey: EnvironmentKey {
+    static let defaultValue: CGFloat = {
+        let window = UIApplication.shared
+            .connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?
+            .windows
+            .first { $0.isKeyWindow }
+        return window?.safeAreaInsets.bottom ?? 0
+    }()
+}
+
 extension EnvironmentValues {
     var screenWidth: CGFloat {
         self[ScreenWidthKey.self]
@@ -48,5 +60,9 @@ extension EnvironmentValues {
     
     var safeScreenHeight: CGFloat {
         self[SafeScreenHeightKey.self]
+    }
+    
+    var safeAreaBottom: CGFloat {
+        self[SafeAreaBottomKey.self]
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Extension/View+.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Extension/View+.swift
@@ -104,26 +104,13 @@ extension View {
         height: CGFloat,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        ZStack {
-            self
-            if isPresented.wrappedValue {
-                Color(white: 0, opacity: 0.6)
-                    .zIndex(1)
-                    .ignoresSafeArea(.all)
-                    .opacity(isPresented.wrappedValue ? 1 : 0)
-            }
-        }
-        .animation(.easeInOut(duration: 0.25), value: isPresented.wrappedValue)
-        .sheet(isPresented: isPresented) {
-            content()
-                .presentationCornerRadius(24)
-                .ignoresSafeArea(.all, edges: .bottom)
-                .presentationDetents([.height(height)])
-                .presentationBackgroundInteraction(.disabled)
-                .presentationDragIndicator(.hidden)
-                .presentationBackground(.white)
-                .interactiveDismissDisabled(true)
-        }
+        self.modifier(
+            WalkieBottomSheet(
+                isPresented: isPresented,
+                height: height,
+                content: content
+            )
+        )
     }
     
     func shimmer(isGray100: Bool) -> some View {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/BottomSheet/WalkieBottomSheet.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/BottomSheet/WalkieBottomSheet.swift
@@ -1,0 +1,41 @@
+//
+//  WalkieBottomSheet.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 6/18/25.
+//
+
+import SwiftUI
+
+struct WalkieBottomSheet<SheetContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let height: CGFloat
+    let content: () -> SheetContent
+    
+    func body(content base: Content) -> some View {
+        ZStack {
+            base
+            
+            if isPresented {
+                Color.black.opacity(0.6)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+            }
+            
+            if isPresented {
+                VStack {
+                    Spacer()
+                    self.content()
+                        .frame(height: height)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.white)
+                        .cornerRadius(24, corners: [.topLeft, .topRight])
+                }
+                .ignoresSafeArea(edges: .bottom)
+                .transition(.move(edge: .bottom))
+                .zIndex(1)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: isPresented)
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/CTAButton/CTAButton.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/CTAButton/CTAButton.swift
@@ -81,7 +81,7 @@ struct CTAButton: View {
             }
         )
         .disabled(size == .modal ? false : !isEnabled)
-        .padding(.horizontal, 16)
+        .padding(.horizontal, size == .modal ? 8 : 16)
     }
 }
 

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/Modal/Modal.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/Modal/Modal.swift
@@ -65,7 +65,9 @@ struct Modal: View {
                         checkButtonAction()
                     }
             case .twobutton:
-                HStack(spacing: -24) {
+                HStack(
+                    spacing: -8
+                ) {
                     CTAButton(
                         title: cancelButtonTitle,
                         style: .modal,

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Map/MapViewModel.swift
@@ -32,7 +32,7 @@ final class MapViewModel: ViewModelable, WebMessageHandling {
     private var timer: Timer?
     private var activity: Activity<WalkieWidgetAttributes>?
     
-    private let locationManager = LocationManager()
+    private let locationManager = LocationManager.shared
     private var totalDistance: CLLocationDistance?
     private var destinationCoord: CLLocationCoordinate2D?
     private var placeName: String = ""

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Complete/OnboardingCompleteView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Complete/OnboardingCompleteView.swift
@@ -13,6 +13,7 @@ struct OnboardingCompleteView: View {
     
     @State var tapStart: Bool = false
     @EnvironmentObject private var appCoordinator: AppCoordinator
+    @Environment(\.safeScreenHeight) private var safeScreenHeight
     
     @State private var showCompleteImage = false
     @State private var showTitle = false
@@ -27,10 +28,11 @@ struct OnboardingCompleteView: View {
                 alignment: .center,
                 spacing: 24
             ) {
+                let imgSize = (safeScreenHeight - 58) * 0.4
                 Image(.imgGift)
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 280, height: 280)
+                    .frame(width: imgSize, height: imgSize)
                     .opacity(showCompleteImage ? 1 : 0)
                 
                 VStack(

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Login/LoginView.swift
@@ -114,8 +114,7 @@ struct LoginView: View {
                                 cancelAction: {},
                                 checkAction: {},
                                 checkTitle: "확인",
-                                cancelTitle: "",
-                                tapDismiss: true
+                                cancelTitle: ""
                             ),
                         onDismiss: {
                             loginViewModel.state = .loading

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SplashView: View {
     
     @StateObject var splashViewModel: SplashViewModel
+    @EnvironmentObject var appCoordinator: AppCoordinator
         
     var body: some View {
         ZStack {
@@ -22,12 +23,14 @@ struct SplashView: View {
         .onAppear {
             splashViewModel.action(.fetchVersion)
         }
-        .permissionBottomSheet(
-            isPresented: $splashViewModel.showUpdateNeed,
-            height: 198,
-            content: {
-                UpdateBSView()
+        .onChange(of: splashViewModel.showUpdateNeed) { _, new in
+            guard new else { return }
+            withAnimation {
+                appCoordinator.buildBottomSheet(height: 198) {
+                    UpdateBSView()
+                        .background(Color.white)
+                }
             }
-        )
+        }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashView.swift
@@ -22,5 +22,12 @@ struct SplashView: View {
         .onAppear {
             splashViewModel.action(.fetchVersion)
         }
+        .permissionBottomSheet(
+            isPresented: $splashViewModel.showUpdateNeed,
+            height: 198,
+            content: {
+                UpdateBSView()
+            }
+        )
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashViewModel.swift
@@ -66,18 +66,17 @@ final class SplashViewModel: NSObject, ViewModelable {
                 lowerThan: remoteVersion
             )
             if needsUpdate {
-                appCoordinator.buildAlert(
-                    title: "워키를 안전한 버전으로\n업데이트 해주세요.",
-                    content: "여러 사용성과 안전성을 업데이트 했어요.",
-                    style: .primary,
-                    button: .onebutton,
-                    cancelButtonAction: {},
-                    checkButtonAction: {
-                        self.openAppStore()
-                    },
-                    checkButtonTitle: "업데이트",
-                    tapDismiss: false
-                )
+//                appCoordinator.buildAlert(
+//                    title: "워키를 안전한 버전으로\n업데이트 해주세요.",
+//                    content: "여러 사용성과 안전성을 업데이트 했어요.",
+//                    style: .primary,
+//                    button: .onebutton,
+//                    cancelButtonAction: {},
+//                    checkButtonAction: {
+//                        self.openAppStore()
+//                    },
+//                    checkButtonTitle: "업데이트"
+//                )
             } else {
                 if TokenKeychainManager.shared.hasToken() {
                     getProfile()
@@ -104,13 +103,13 @@ final class SplashViewModel: NSObject, ViewModelable {
         return false
     }
     
-    private func openAppStore() {
-        guard let url = URL(string: URLConstant.appStoreURL) else { return }
-        
-        if UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-        }
-    }
+//    func openAppStore() {
+//        guard let url = URL(string: URLConstant.appStoreURL) else { return }
+//        
+//        if UIApplication.shared.canOpenURL(url) {
+//            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+//        }
+//    }
     
     private func getProfile() {
         getProfileUseCase.execute()

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/SplashViewModel.swift
@@ -16,6 +16,7 @@ final class SplashViewModel: NSObject, ViewModelable {
     private var cancellables = Set<AnyCancellable>()
     let appCoordinator: AppCoordinator
     private let getProfileUseCase: GetProfileUseCase
+    var showUpdateNeed: Bool = false
     
     enum Action {
         case fetchVersion
@@ -66,17 +67,7 @@ final class SplashViewModel: NSObject, ViewModelable {
                 lowerThan: remoteVersion
             )
             if needsUpdate {
-//                appCoordinator.buildAlert(
-//                    title: "워키를 안전한 버전으로\n업데이트 해주세요.",
-//                    content: "여러 사용성과 안전성을 업데이트 했어요.",
-//                    style: .primary,
-//                    button: .onebutton,
-//                    cancelButtonAction: {},
-//                    checkButtonAction: {
-//                        self.openAppStore()
-//                    },
-//                    checkButtonTitle: "업데이트"
-//                )
+                showUpdateNeed = true
             } else {
                 if TokenKeychainManager.shared.hasToken() {
                     getProfile()
@@ -102,14 +93,6 @@ final class SplashViewModel: NSObject, ViewModelable {
         }
         return false
     }
-    
-//    func openAppStore() {
-//        guard let url = URL(string: URLConstant.appStoreURL) else { return }
-//        
-//        if UIApplication.shared.canOpenURL(url) {
-//            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-//        }
-//    }
     
     private func getProfile() {
         getProfileUseCase.execute()

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/UpdateBSView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/UpdateBSView.swift
@@ -30,7 +30,7 @@ struct UpdateBSView: View {
             }
             
             HStack(
-                spacing: 8
+                spacing: 0
             ) {
                 CTAButton(
                     title: "앱을 종료할게요",
@@ -55,6 +55,7 @@ struct UpdateBSView: View {
                     }
                 )
             }
+            .padding(.horizontal, 8)
         }
     }
     
@@ -65,8 +66,4 @@ struct UpdateBSView: View {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
-}
-
-#Preview {
-    UpdateBSView()
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/UpdateBSView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Onboarding/Splash/UpdateBSView.swift
@@ -1,0 +1,72 @@
+//
+//  UpdateBSView.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 6/13/25.
+//
+
+import SwiftUI
+import WalkieCommon
+
+struct UpdateBSView: View {
+    
+    var body: some View {
+        VStack(
+            alignment: .center,
+            spacing: 20
+        ) {
+            VStack(
+                alignment: .center,
+                spacing: 4
+            ) {
+                Text("새로운 버전이 업데이트 되었어요")
+                    .font(.H4)
+                    .foregroundColor(WalkieCommonAsset.gray700.swiftUIColor)
+                
+                Text("유저분들의 의견을 반영하여 사용성을 개선했어요!\n지금 바로 업데이트하고 즐겨보세요")
+                    .font(.B2)
+                    .foregroundColor(WalkieCommonAsset.gray500.swiftUIColor)
+                    .multilineTextAlignment(.center)
+            }
+            
+            HStack(
+                spacing: 8
+            ) {
+                CTAButton(
+                    title: "앱을 종료할게요",
+                    style: .modal,
+                    size: .modal,
+                    isEnabled: true,
+                    buttonAction: {
+                        UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            exit(0)
+                        }
+                    }
+                )
+                
+                CTAButton(
+                    title: "업데이트",
+                    style: .primary,
+                    size: .modal,
+                    isEnabled: true,
+                    buttonAction: {
+                        openAppStore()
+                    }
+                )
+            }
+        }
+    }
+    
+    private func openAppStore() {
+        guard let url = URL(string: URLConstant.appStoreURL) else { return }
+        
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}
+
+#Preview {
+    UpdateBSView()
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 enum AppScene: AppRoute {
     
@@ -38,18 +39,12 @@ enum AppScene: AppRoute {
 
 enum AppSheet: AppRoute {
     
-    case eggDetail
-    case authBottomSheet
-    case homeAlarmBottomSheet
+    case homeAlarm(height: CGFloat, content: AnyView)
     
     public var id: String {
         switch self {
-        case .eggDetail:
-            return "eggDetail"
-        case .authBottomSheet:
-            return "authBottomSheet"
-        case .homeAlarmBottomSheet:
-            return "homeAlarmBottomSheet"
+        case .homeAlarm:
+            return "homeAlarm"
         }
     }
     
@@ -58,6 +53,20 @@ enum AppSheet: AppRoute {
     }
     func hash(into hasher: inout Hasher) {
         id.hash(into: &hasher)
+    }
+    var height: CGFloat {
+        switch self {
+        case .homeAlarm(let height, _):
+            return height
+        }
+    }
+
+    @ViewBuilder
+    var view: some View {
+      switch self {
+      case .homeAlarm(_, let view):
+          view
+      }
     }
 }
 

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -71,15 +71,14 @@ enum AppFullScreenCover: AppRoute, Identifiable, Hashable {
         cancelAction: () -> Void,
         checkAction: () -> Void,
         checkTitle: String,
-        cancelTitle: String,
-        tapDismiss: Bool
+        cancelTitle: String
     )
     
     var id: String {
         switch self {
         case .hatchEgg:
             return "hatchEgg"
-        case .alert(let title, _, _, _, _, _, _, _, _):
+        case .alert(let title, _, _, _, _, _, _, _):
             return "alert_\(title)"
         }
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -60,13 +60,13 @@ enum AppSheet: AppRoute {
             return height
         }
     }
-
+    
     @ViewBuilder
     var view: some View {
-      switch self {
-      case .homeAlarm(_, let view):
-          view
-      }
+        switch self {
+        case .homeAlarm(_, let view):
+            view
+        }
     }
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 커스텀 바텀시트 구현
- 권한바텀시트는 드래그와 같은 사용자 `interaction`을 막아놓고 뷰가 그려지자마자 보여야 해서 애니메이션이 사라지는 이슈가 발생했습니다.
- 이를 해결하기 위해서 기존의 `bottomsheet` 와는 다르게 커스텀한 `WalkieBottomSheet`를 따로 구현했습니다!

```swift
struct WalkieBottomSheet<SheetContent: View>: ViewModifier {
    @Binding var isPresented: Bool
    let height: CGFloat
    let content: () -> SheetContent
}

// View+
func permissionBottomSheet<Content: View>(
    isPresented: Binding<Bool>,
    height: CGFloat,
    @ViewBuilder content: @escaping () -> Content
) -> some View {
    self.modifier(
        WalkieBottomSheet(
            isPresented: isPresented,
            height: height,
            content: content
        )
    )
}
```

### 라이브액티비티 업데이트 안되는 이슈 해결
- `LocationManager`를 `MapViewModel`에서는 인스턴스를 새로 생성해서 쓰고 있어서 생긴 이슈였습니다!
- `LocationManager.shared` 싱글톤 형태로 바꿔서 해결완

🚨 **참고 사항**
- 홈화면에서 권한바텀시트 -> 알럿 뜰때 알럿이 지금 애니메이션이 사라져있는 상태라서 깜빡이는 느낌으로 보이는거 같아요! 알럿 애니메이션 해결했는데도 그렇게 보인다면,, 그때 다시 해결방법을 찾아보겠습니다!

📸 **스크린샷**
|기능|스크린샷|스크린샷|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/714fb9c3-1a1d-467a-b1c7-ecb52ed7dbbb" width ="250">|<img src = "https://github.com/user-attachments/assets/a8d136e1-1d4d-42e2-b476-44d36089bf83" width ="250">|

📟 **관련 이슈**
- Resolved: #169 
