### PR TITLE
[Hotfix] #191 - 알 선택 버튼 로직 수정

### DIFF
--- a/Walkie-iOS/Project.swift
+++ b/Walkie-iOS/Project.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-let walkieVersion: String = "1.1.0"
+let walkieVersion: String = "1.1.1"
 let plistVersion: Plist.Value = .string(walkieVersion)
 let settingVersion: SettingValue = .string(walkieVersion)
 

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -309,6 +309,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
         @ViewBuilder content: @escaping () -> Content,
         disableInteractive: Bool = false
     ) {
+        guard sheet == nil else { return }
         presentSheet(
             AppSheet.bottomSheet(
                 height: height,

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeStatsView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeStatsView.swift
@@ -126,14 +126,14 @@ struct HomeStatsView: View {
                         .frame(width: eggWidth, height: eggHeight)
                         .overlay(alignment: .bottom) {
                             if !showWarning {
-                                NavigationLink(
-                                    destination: DIContainer.shared.buildEggView(appCoordinator: appCoordinator)
-                                ) {
+                                Button(action: {
+                                    appCoordinator.push(AppScene.egg)
+                                }, label: {
                                     Text("알을 선택해 주세요")
                                         .font(.H5)
                                         .foregroundColor(WalkieCommonAsset.blue50.swiftUIColor)
                                         .underline()
-                                }
+                                })
                                 .frame(height: 24)
                                 .padding(.bottom, emptyButtonInset)
                             }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 알 엠티뷰 버튼 수정
- 부화중인 알이 없을때 나오는 '알을 선택해 주세요' 버튼이 `NavigationLink`로 되어있어서 앱이 터지는 이슈가 발생했습니다.
- 이를 `appCoordinator.push`로 바꿔서 이슈 해결했습니다.

### 바텀시트 이슈 수정
- 기존 바텀시트가 완전히 사라지기 전에 다른 바텀시트를 띄우면 fullscreencover로 발생하는 이슈가 있었습니다. (아래 영상 참고)
- `guard sheet == nil else { return }`를 추가해서 띄워진 시트가 있으면 `return`하도록 했습니다.

📸 **스크린샷**
|기능|이슈상황|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/d18f78fa-1b91-409f-8a7c-ad1954b745a4" width ="250">|

📟 **관련 이슈**
- Resolved: #191 
