### PR TITLE
[Refactor] #203 - 권한 및 이벤트 로직 이전 및 홈뷰 우선순위 조정

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -412,7 +412,11 @@ extension AppCoordinator {
                 self.buildBottomSheet(
                     height: 369,
                     content: {
-                        HomeAlarmBSView()
+                        HomeAlarmBSView(
+                            onConfirm: {
+                                self.permissionFlow?.nextStep()
+                            }
+                        )
                     },
                     disableInteractive: true
                 )

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/EventFlowCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/EventFlowCoordinator.swift
@@ -1,0 +1,68 @@
+//
+//  EventFlowCoordinator.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 7/21/25.
+//
+
+import Foundation
+import Combine
+
+final class EventFlowCoordinator: ObservableObject {
+    
+    private let remoteConfigManager: RemoteConfigManaging
+    private let getEventEggUseCase: GetEventEggUseCase
+    
+    @Published private(set) var eventEggEntity: EventEggEntity?
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        remoteConfigManager: RemoteConfigManaging = RemoteConfigManager.shared,
+        getEventEggUseCase: GetEventEggUseCase
+    ) {
+        self.remoteConfigManager = remoteConfigManager
+        self.getEventEggUseCase  = getEventEggUseCase
+    }
+
+    func checkEvent(completion: (() -> Void)? = nil) {
+        Task {
+            do {
+                try await remoteConfigManager.fetchAndActivate()
+                guard remoteConfigManager.boolValue(for: .eggEventEnabled) else { return }
+
+                let now = Date()
+                let calendar = Calendar.current
+                let oneDayAgo = calendar.date(
+                    byAdding: .day, value: -1, to: now
+                ) ?? now
+                
+                let lastDate = UserManager.shared.getLastVisitedDate
+                ?? oneDayAgo
+                let daysDiff = calendar.dateComponents(
+                    [.day],
+                    from: calendar.startOfDay(for: lastDate),
+                    to: calendar.startOfDay(for: now)
+                ).day ?? 0
+                
+                guard daysDiff >= 1 else { return }
+                
+                getEventEggUseCase.getEventEgg()
+                    .walkieSink(
+                        with: self,
+                        receiveValue: { _, entity in
+                            self.eventEggEntity = entity.canReceive ? entity : nil
+                            UserManager.shared.setLastVisitedDate(now)
+                            completion?()
+                        },
+                        receiveFailure: { _, _ in
+                            self.eventEggEntity = nil
+                            completion?()
+                        }
+                    )
+                    .store(in: &cancellables)
+            } catch {
+            }
+        }
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/PermissionFlowCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/PermissionFlowCoordinator.swift
@@ -80,6 +80,7 @@ final class PermissionFlowCoordinator {
     }
     
     func nextStep() {
+        currentIndex += 1
         runCurrentStep()
     }
     
@@ -126,13 +127,13 @@ final class PermissionFlowCoordinator {
         
         switch () {
         case _ where bothAuth:
-            runCurrentStep()
+            nextStep()
         case _ where anyNotDetermined:
             locationUC.requestIfNeeded()
                 .flatMap { _ in self.motionUC.requestIfNeeded() }
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in
-                    self?.runCurrentStep()
+                    self?.nextStep()
                 }
                 .store(in: &cancellables)
         case _ where anyDenied:
@@ -146,7 +147,6 @@ final class PermissionFlowCoordinator {
         default:
             break
         }
-        currentIndex += 1
     }
     
     private func handleNotify(
@@ -155,12 +155,12 @@ final class PermissionFlowCoordinator {
     ) {
         switch status {
         case .authorized:
-            runCurrentStep()
+            nextStep()
         case .notDetermined:
             notifyUC.requestIfNeeded()
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in
-                    self?.runCurrentStep()
+                    self?.nextStep()
                 }
                 .store(in: &cancellables)
         case .denied:
@@ -172,6 +172,5 @@ final class PermissionFlowCoordinator {
                 { _, _, _ in }
             )
         }
-        currentIndex += 1
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/PermissionFlowCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/PermissionFlowCoordinator.swift
@@ -1,0 +1,177 @@
+//
+//  PermissionFlowCoordinator.swift
+//  Walkie-iOS
+//
+//  Created by 고아라 on 7/18/25.
+//
+
+import Foundation
+import Combine
+
+enum PermissionStep: CaseIterable {
+    case locationMotion
+    case notification
+    
+    func alertTitle(
+        loc: Bool,
+        mot: Bool
+    ) -> String {
+        switch (loc, mot) {
+        case (false, false):
+            return "접근권한 허용"
+        case (false, true):
+            return "위치 권한 허용"
+        case (true, false):
+            return "동작 및 피트니스 권한 허용"
+        case (true, true):
+            return ""
+        }
+    }
+    
+    func alertContent(
+        loc: Bool,
+        mot: Bool
+    ) -> String {
+        switch (loc, mot) {
+        case (false, false):
+            return "원활한 서비스 이용을 위해 ‘위치’,\n‘동작 및 피트니스’ 권한을 모두 허용해 주세요"
+        case (false, true):
+            return "스팟을 탐색하기 위해 백그라운드 동작 시의\n위치 정보 접근을 허가해 주세요.\n\n1. 위치를 선택\n2. 위치 접근 허용을 ‘항상'으로 설정"
+        case (true, false):
+            return "걸음수 측정을 위해 권한이 필요해요"
+        default:
+            return ""
+        }
+    }
+}
+
+final class PermissionFlowCoordinator {
+    
+    private let locationUC: LocationPermissionUseCase
+    private let motionUC: MotionPermissionUseCase
+    private let notifyUC: NotificationPermissionUseCase
+    private var cancellables = Set<AnyCancellable>()
+    
+    private let steps = PermissionStep.allCases
+    private var currentIndex: Int = 0
+    
+    var onDenied: (
+        _ step: PermissionStep,
+        _ locAllowed: Bool,
+        _ motAllowed: Bool,
+        _ showBottomSheet: (_ title: String, _ message: String, _ onOK: @escaping () -> Void) -> Void,
+        _ showAlert: (_ title: String, _ message: String, _ onOK: @escaping () -> Void) -> Void
+    ) -> Void = { _, _, _, _, _ in }
+    var onAllAuthorized: () -> Void = {}
+    
+    init(
+        locationUC: LocationPermissionUseCase,
+        motionUC: MotionPermissionUseCase,
+        notifyUC: NotificationPermissionUseCase
+    ) {
+        self.locationUC = locationUC
+        self.motionUC   = motionUC
+        self.notifyUC   = notifyUC
+    }
+    
+    func start() {
+        currentIndex = 0
+        runCurrentStep()
+    }
+    
+    func nextStep() {
+        runCurrentStep()
+    }
+    
+    private func runCurrentStep() {
+        guard currentIndex < steps.count else {
+            onAllAuthorized()
+            return
+        }
+        let step = steps[currentIndex]
+        switch step {
+        case .locationMotion:
+            Publishers.CombineLatest(
+                locationUC.check(),
+                motionUC.check()
+            )
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] loc, mot in
+                self?.handleLocMot(
+                    loc: loc,
+                    mot: mot,
+                    step: .locationMotion
+                )
+            }
+            .store(in: &cancellables)
+            
+        case .notification:
+            notifyUC.check()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] status in
+                    self?.handleNotify(status: status, step: .notification)
+                }
+                .store(in: &cancellables)
+        }
+    }
+    
+    private func handleLocMot(
+        loc: PermissionState,
+        mot: PermissionState,
+        step: PermissionStep
+    ) {
+        let bothAuth = loc == .authorized && mot == .authorized
+        let anyNotDetermined = loc == .notDetermined || mot == .notDetermined
+        let anyDenied = loc == .denied || mot == .denied
+        
+        switch () {
+        case _ where bothAuth:
+            runCurrentStep()
+        case _ where anyNotDetermined:
+            locationUC.requestIfNeeded()
+                .flatMap { _ in self.motionUC.requestIfNeeded() }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    self?.runCurrentStep()
+                }
+                .store(in: &cancellables)
+        case _ where anyDenied:
+            onDenied(
+                step,
+                loc == .authorized,
+                mot == .authorized,
+                { _, _, _ in },
+                { _, _, _ in }
+            )
+        default:
+            break
+        }
+        currentIndex += 1
+    }
+    
+    private func handleNotify(
+        status: PermissionState,
+        step: PermissionStep
+    ) {
+        switch status {
+        case .authorized:
+            runCurrentStep()
+        case .notDetermined:
+            notifyUC.requestIfNeeded()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    self?.runCurrentStep()
+                }
+                .store(in: &cancellables)
+        case .denied:
+            onDenied(
+                step,
+                true,
+                true,
+                { _, _, _ in },
+                { _, _, _ in }
+            )
+        }
+        currentIndex += 1
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/StepCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/StepCoordinator.swift
@@ -81,7 +81,6 @@ final class StepCoordinator {
     }
     
     func presentHatchEggScreen() {
-        appCoordinator?.presentFullScreenCover(AppFullScreenCover.hatchEgg)
         hatchSubject.send(true)
         stopStepUpdates()
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -29,7 +29,6 @@ final class DIContainer {
     private lazy var updateStepForegroundUseCase = DefaultUpdateStepForegroundUseCase(store: stepStatusStore)
     private lazy var updateStepBackgroundUseCase = DefaultUpdateStepBackgroundUseCase(store: stepStatusStore)
     private lazy var checkHatchConditionUseCase = DefaultCheckHatchConditionUseCase(store: stepStatusStore)
-    private lazy var permissionUseCase = DefaultPermissionUseCase.make()
     private lazy var locationPermissionUseCase = DefaultLocationPermissionUseCase()
     private lazy var motionPermissionUseCase = DefaultMotionPermissionUseCase()
     private lazy var notificationPermissionUseCase = DefaultNotificationPermissionUseCase()
@@ -112,12 +111,7 @@ extension DIContainer {
                 stepStatusStore: stepStatusStore
             ),
             appCoordinator: appCoordinator,
-            stepStatusStore: stepStatusStore,
-            getEventEggUseCase: DefaultGetEventEggUseCase(
-                eggRepository: eggRepo,
-                stepStatusStore: stepStatusStore
-            ),
-            permissionUseCase: permissionUseCase
+            stepStatusStore: stepStatusStore
         )
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -49,6 +49,10 @@ extension DIContainer {
         return DefaultGetEggPlayUseCase(memberRepository: memberRepo, stepStatusStore: stepStatusStore)
     }
     
+    func resolveGetEventEggUseCase() -> GetEventEggUseCase {
+        return DefaultGetEventEggUseCase(eggRepository: eggRepo, stepStatusStore: stepStatusStore)
+    }
+    
     func resolveUpdateStepForegroundUseCase() -> UpdateStepForegroundUseCase {
         return updateStepForegroundUseCase
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -30,6 +30,9 @@ final class DIContainer {
     private lazy var updateStepBackgroundUseCase = DefaultUpdateStepBackgroundUseCase(store: stepStatusStore)
     private lazy var checkHatchConditionUseCase = DefaultCheckHatchConditionUseCase(store: stepStatusStore)
     private lazy var permissionUseCase = DefaultPermissionUseCase.make()
+    private lazy var locationPermissionUseCase = DefaultLocationPermissionUseCase()
+    private lazy var motionPermissionUseCase = DefaultMotionPermissionUseCase()
+    private lazy var notificationPermissionUseCase = DefaultNotificationPermissionUseCase()
     
     lazy var stepStatusStore = DefaultStepStatusStore()
 }
@@ -56,6 +59,18 @@ extension DIContainer {
     
     func resolveCheckHatchConditionUseCase() -> CheckHatchConditionUseCase {
         return checkHatchConditionUseCase
+    }
+    
+    func resolveLocationPermissionUseCase() -> LocationPermissionUseCase {
+        return locationPermissionUseCase
+    }
+    
+    func resolveMotionPermissionUseCase() -> MotionPermissionUseCase {
+        return motionPermissionUseCase
+    }
+    
+    func resolveNotificationPermissionUseCase() -> NotificationPermissionUseCase {
+        return notificationPermissionUseCase
     }
 }
 

--- a/Walkie-iOS/Walkie-iOS/Sources/Const/CharacterLiterals.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Const/CharacterLiterals.swift
@@ -42,49 +42,38 @@ enum JellyfishType: String, CaseIterable {
         }
     }
     
+    private static let mapTable: [Int: [Int: JellyfishType]] = [
+        0: [
+            0: .defaultJellyfish,
+            1: .red,
+            2: .green,
+            3: .purple,
+            4: .pink
+        ],
+        1: [
+            0: .bunny,
+            1: .starfish
+        ],
+        2: [
+            0: .shocked,
+            1: .strawberry
+        ]
+    ]
+    
     static func mapCharacterType(
         rank: Int,
         characterClass: Int
     ) throws -> JellyfishType {
-        switch rank {
-        case 0:
-            switch characterClass {
-            case 0:
-                return .defaultJellyfish
-            case 1:
-                return .red
-            case 2:
-                return .green
-            case 3:
-                return .purple
-            case 4:
-                return .pink
-            default:
-                throw NetworkError.responseDecodingError
-            }
-        case 1:
-            switch characterClass {
-            case 0:
-                return .bunny
-            case 1:
-                return .starfish
-            default:
-                throw NetworkError.responseDecodingError
-            }
-        case 2:
-            switch characterClass {
-            case 0:
-                return .shocked
-            case 1:
-                return .strawberry
-            default:
-                throw NetworkError.responseDecodingError
-            }
-        case 3:
+        if rank == 3 {
             return .space
-        default:
+        }
+        guard
+            let classMap = mapTable[rank],
+            let jelly    = classMap[characterClass]
+        else {
             throw NetworkError.responseDecodingError
         }
+        return jelly
     }
 }
 
@@ -118,46 +107,34 @@ enum DinoType: String, CaseIterable {
         }
     }
     
+    private static let mapTable: [Int: [Int: DinoType]] = [
+        0: [
+            0: .defaultDino,
+            1: .red,
+            2: .mint,
+            3: .purple,
+            4: .pink
+        ],
+        1: [
+            0: .reindeer,
+            1: .nessie
+        ],
+        2: [
+            0: .pancake,
+            1: .melonSoda
+        ]
+    ]
+    
     static func mapCharacterType(rank: Int, characterClass: Int) throws -> DinoType {
-        switch rank {
-        case 0:
-            switch characterClass {
-            case 0:
-                return .defaultDino
-            case 1:
-                return .red
-            case 2:
-                return .mint
-            case 3:
-                return .purple
-            case 4:
-                return .pink
-            default:
-                throw NetworkError.responseDecodingError
-            }
-        case 1:
-            switch characterClass {
-            case 0:
-                return .reindeer
-            case 1:
-                return .nessie
-            default:
-                throw NetworkError.responseDecodingError
-            }
-        case 2:
-            switch characterClass {
-            case 0:
-                return .pancake
-            case 1:
-                return .melonSoda
-            default:
-                throw NetworkError.responseDecodingError
-            }
-        case 3:
+        if rank == 3 {
             return .dragon
-        default:
+        }
+        guard
+            let classMap = mapTable[rank],
+            let dino     = classMap[characterClass]
+        else {
             throw NetworkError.responseDecodingError
         }
+        return dino
     }
-
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Data/Repository/Member/DefaultMemberRepository.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Data/Repository/Member/DefaultMemberRepository.swift
@@ -44,7 +44,10 @@ extension DefaultMemberRepository: MemberRepository {
 
                 // EggEntity 생성
                 if type == 0 {
-                    let jellyfishType = try JellyfishType.mapCharacterType(rank: characterRank, characterClass: characterClass)
+                    let jellyfishType = try JellyfishType.mapCharacterType(
+                        rank: characterRank,
+                        characterClass: characterClass
+                    )
                     return EggEntity(
                         eggId: eggID,
                         eggType: EggType.from(number: eggRank),

--- a/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Calendar/DefaultCalendarUseCase.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Domain/UseCase/Calendar/DefaultCalendarUseCase.swift
@@ -22,8 +22,10 @@ final class DefaultCalendarUseCase: CalendarUseCase {
         }
         
         // 과거 주, 현재 주, 미래 주의 시작 날짜(일요일)
-        guard let pastSunday = calendar.date(byAdding: .day, value: -7, to: currentSunday),
-              let futureSunday = calendar.date(byAdding: .day, value: 7, to: currentSunday) else {
+        guard
+            let pastSunday = calendar.date(byAdding: .day, value: -7, to: currentSunday),
+            let futureSunday = calendar.date(byAdding: .day, value: 7, to: currentSunday)
+        else {
             return ([], [], [])
         }
         
@@ -33,9 +35,10 @@ final class DefaultCalendarUseCase: CalendarUseCase {
         var futureWeek: [Date] = []
         
         for day in 0..<7 {
-            if let pastDay = calendar.date(byAdding: .day, value: day, to: pastSunday),
-               let presentDay = calendar.date(byAdding: .day, value: day, to: currentSunday),
-               let futureDay = calendar.date(byAdding: .day, value: day, to: futureSunday) {
+            if
+                let pastDay = calendar.date(byAdding: .day, value: day, to: pastSunday),
+                let presentDay = calendar.date(byAdding: .day, value: day, to: currentSunday),
+                let futureDay = calendar.date(byAdding: .day, value: day, to: futureSunday) {
                 pastWeek.append(pastDay)
                 presentWeek.append(presentDay)
                 futureWeek.append(futureDay)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/HomeView.swift
@@ -13,16 +13,6 @@ struct HomeView: View {
     
     @StateObject var viewModel: HomeViewModel
     @Environment(\.screenWidth) var screenWidth
-    @Environment(\.screenHeight) var screenHeight
-    @Environment(\.safeAreaBottom) private var bottomInset
-    @State var navigateAlarmList: Bool = false
-    
-    @State private var showLocationBS: Bool = false
-    @State private var showMotionBS: Bool = false
-    @State private var showAlarmBS: Bool = false
-    @State private var showBS: Bool = false
-    @State private var hasShownAlarmBSOnce: Bool = false
-    
     @EnvironmentObject private var appCoordinator: AppCoordinator
     
     var body: some View {
@@ -103,25 +93,6 @@ struct HomeView: View {
         }
         .onDisappear {
             viewModel.action(.homeWillDisappear)
-        }
-        .onChange(of: viewModel.eventEggState) { _, newState in
-            switch newState {
-            case .loaded(let eventEggState):
-                if eventEggState.showEventEgg {
-                    appCoordinator.buildEventAlert(
-                        title: "알 1개를 선물받았어요!",
-                        style: .primary,
-                        button: .twobutton,
-                        cancelButtonAction: { },
-                        checkButtonAction: {
-                            appCoordinator.push(AppScene.egg)
-                        },
-                        dDay: eventEggState.dDay
-                    )
-                }
-            default:
-                break
-            }
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeAlarmBSView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeAlarmBSView.swift
@@ -11,9 +11,8 @@ import WalkieCommon
 
 struct HomeAlarmBSView: View {
     
-    @ObservedObject var viewModel: HomeViewModel
     @Environment(\.screenWidth) var screenWidth
-    @Binding var isPresented: Bool
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         VStack(
@@ -44,8 +43,7 @@ struct HomeAlarmBSView: View {
                 spacing: 8
             ) {
                 Button(action: {
-                    isPresented = false
-                    viewModel.action(.homeAlarmAllowTapped)
+                    dismiss()
                 }, label: {
                     Text("나중에")
                         .font(.B1)
@@ -58,8 +56,7 @@ struct HomeAlarmBSView: View {
                 
                 Button(action: {
                     openSettings()
-                    isPresented = false
-                    viewModel.action(.homeAlarmAllowTapped)
+                    dismiss()
                 }, label: {
                     Text("알림받기")
                         .font(.B1)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeAlarmBSView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeAlarmBSView.swift
@@ -13,6 +13,7 @@ struct HomeAlarmBSView: View {
     
     @Environment(\.screenWidth) var screenWidth
     @Environment(\.dismiss) private var dismiss
+    let onConfirm: () -> Void
     
     var body: some View {
         VStack(
@@ -44,6 +45,7 @@ struct HomeAlarmBSView: View {
             ) {
                 Button(action: {
                     dismiss()
+                    onConfirm()
                 }, label: {
                     Text("나중에")
                         .font(.B1)
@@ -57,6 +59,7 @@ struct HomeAlarmBSView: View {
                 Button(action: {
                     openSettings()
                     dismiss()
+                    onConfirm()
                 }, label: {
                     Text("알림받기")
                         .font(.B1)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeAuthBSView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeAuthBSView.swift
@@ -11,10 +11,10 @@ import WalkieCommon
 
 struct HomeAuthBSView: View {
     
-    @ObservedObject var viewModel: HomeViewModel
-    @Binding var isPresented: Bool
+    @Environment(\.dismiss) private var dismiss
     let showLocation: Bool
     let showMotion: Bool
+    let onConfirm: () -> Void
     
     var body: some View {
         VStack(spacing: 20) {
@@ -44,8 +44,8 @@ struct HomeAuthBSView: View {
                 size: .large,
                 isEnabled: true,
                 buttonAction: {
-                    viewModel.action(.homeAuthAllowTapped)
-                    isPresented = false
+                    dismiss()
+                    onConfirm()
                 }
             )
         }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeStatsView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/Home/View/HomeStatsView.swift
@@ -51,7 +51,7 @@ struct HomeStatsView: View {
                 if let eggEffect = homeStatsState.eggEffectImage {
                     Image(eggEffect)
                         .resizable()
-                        .scaledToFit()
+                        .scaledToFill()
                         .frame(width: width, height: 343)
                 }
             }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Review/ReviewView.swift
@@ -118,7 +118,9 @@ struct ReviewView: View {
                         endDate: calendarViewModel.state.futureWeek[6].convertToDateString(),
                         completion: { result in
                             if result {
-                                viewModel.action(.showReviewList(dateString: viewModel.selectedDate.convertToDateString()))
+                                viewModel.action(.showReviewList(
+                                    dateString: viewModel.selectedDate.convertToDateString())
+                                )
                                 calendarViewModel.action(.updateReviewDates(viewModel.reviewDateList))
                             }
                         }
@@ -171,7 +173,9 @@ struct ReviewView: View {
                         endDate: calendarViewModel.state.futureWeek[6].convertToDateString(),
                         completion: { result in
                             if result {
-                                viewModel.action(.showReviewList(dateString: viewModel.selectedDate.convertToDateString()))
+                                viewModel.action(.showReviewList(
+                                    dateString: viewModel.selectedDate.convertToDateString())
+                                )
                                 calendarViewModel.action(.updateReviewDates(viewModel.reviewDateList))
                             }
                         }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### `PermissionFlowCoordinator` 구현
- 권한 흐름 제어를 위한 코디네이터 분리
- `currentIndex`를 통해서 권한 단계 제어했고, 거부했을때와 모든 권한 체크했을때로 콜백 분리해서 관리
```swift
 private var currentIndex: Int = 0
 var onDenied: (
    _ step: PermissionStep,
    _ locAllowed: Bool,
    _ motAllowed: Bool,
    _ showBottomSheet: (_ title: String, _ message: String, _ onOK: @escaping () -> Void) -> Void,
    _ showAlert: (_ title: String, _ message: String, _ onOK: @escaping () -> Void) -> Void
) -> Void = { _, _, _, _, _ in }
var onAllAuthorized: () -> Void = {}
```

### `EventFlowCoordinator` 구현
- 이벤트 팝업 여부 및 서버통신 로직 분리
- 기존 로직과 동일하고, 이벤트 호출 성공시에만 `eventEggEntity`에 할당
```swift
getEventEggUseCase.getEventEgg()
    .walkieSink(
        with: self,
        receiveValue: { _, entity in
            self.eventEggEntity = entity.canReceive ? entity : nil
            UserManager.shared.setLastVisitedDate(now)
            completion?()
        },
        receiveFailure: { _, _ in
            self.eventEggEntity = nil
            completion?()
        }
    )
    .store(in: &cancellables)
```

### AppCoordinator 리팩토링
- 홈화면에 진입했을때 `handleHomeEntry` 함수를 호출해서 부화 이벤트 중지 및 권한, 이벤트 플로우 검사
```swift
func handleHomeEntry() {
    stopStepUpdates()
    permissionFlow?.start()
    eventFlow?.checkEvent()
}
```
- 권한 체크 완료 후에는 부화 여부 체크 및 부화 종료 후 액션 정의
```swift
permissionFlow?.onAllAuthorized = {
    DispatchQueue.main.async {
        self.sheet = nil
        self.startStepUpdates()
        self.onHatchDismiss = { [weak self] in
            self?.showEventEggAlert()
        }
    }
}
```
- 부화할거면 `hatchEgg` 보여주고 `dimiss`될때 이벤트 알럿 보여주는 액션(`onHatchDismiss`) 실행함. 
- 부화안할거면 바로 이벤트 알럿 띄우는 `showEventEggAlert` 함수 실행
```swift
if willHatch {
    self.presentFullScreenCover(
        AppFullScreenCover.hatchEgg,
        onDismiss: self.onHatchDismiss
    )
    self.onHatchDismiss = nil
} else {
    showEventEggAlert()
}
```

### 홈화면 알 이펙트 이미지 QA 반영
- `.scaledToFill()`로 수정해서 이미지 여백 안생기도록 수정

🚨 **참고 사항**
- 권한 → 부화 → 이벤트 이 3가지 케이스 모두 나오는 화면만 캡쳐해놨는데, 이외 케이스들도 확인 후 전달드리겠습니다!

📸 **스크린샷**

https://github.com/user-attachments/assets/524a9594-7ad7-4b34-a906-cfca9311f6ad

📟 **관련 이슈**
- Resolved: #203 
