### PR TITLE
[Feat/Hotfix] #206, #205 - 닉네임 변경 Domain/Presentation Layer 구현, 알 부화 뷰 dim 영역 디자인 변경사항 및 수정사항 반영

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -115,6 +115,8 @@ final class AppCoordinator: Coordinator, ObservableObject {
             buildFeedback()
         case let .withdraw(nickname):
             diContainer.buildWithdrawView(appCoordinator: self, nickname: nickname)
+        case let .changeNickname(viewModel):
+            diContainer.buildMypageChangeNicknameView(viewModel: viewModel)
         }
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -210,10 +210,11 @@ final class AppCoordinator: Coordinator, ObservableObject {
     @ViewBuilder
     private func buildSetting(_ item: MypageSettingSectionItem) -> some View {
         switch item {
-        case let .myInfo(isPublic):
+        case let .myInfo(isPublic, nickname):
             let viewModel = diContainer.makeMypageMyInformationViewModel(
                 appCoordinator: self,
-                isPublic: isPublic
+                isPublic: isPublic,
+                nickname: nickname
             )
             MypageMyInformationView(viewModel: viewModel)
                 .toolbar(.hidden, for: .tabBar)

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -342,4 +342,10 @@ extension DIContainer {
             hatchEggViewModel: self.makeHatchEggViewModel()
         )
     }
+    
+    func buildMypageChangeNicknameView(viewModel: MypageMyInformationViewModel) -> MypageChangeNicknameView {
+        return MypageChangeNicknameView(
+            viewModel: viewModel
+        )
+    }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Manager/DIContainer.swift
@@ -148,7 +148,8 @@ extension DIContainer {
     
     func makeMypageMyInformationViewModel(
         appCoordinator: AppCoordinator,
-        isPublic: Bool
+        isPublic: Bool,
+        nickname: String
     ) -> MypageMyInformationViewModel {
         return MypageMyInformationViewModel(
             appCoordinator: appCoordinator,
@@ -156,7 +157,8 @@ extension DIContainer {
                 memberRepository: memberRepo,
                 stepStatusStore: stepStatusStore
             ),
-            isPublic: isPublic
+            isPublic: isPublic,
+            nickname: nickname
         )
     }
     

--- a/Walkie-iOS/Walkie-iOS/Sources/Data/Service/Member/MemberTarget.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Data/Service/Member/MemberTarget.swift
@@ -65,7 +65,7 @@ extension MemberTarget {
     static func patchUserProfile(memberNickname: String) -> MemberTarget {
         MemberTarget(
             path: URLConstant.members,
-            method: .post,
+            method: .patch,
             task: .requestJSONEncodable(["memberNickname": memberNickname])
         )
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
@@ -20,7 +20,7 @@ struct HatchEggView: View {
             Color(white: 0, opacity: 0.6)
                 .ignoresSafeArea()
                 .onTapGesture {
-                    if hatchEggViewModel.animationState.isShowingGlowEffect {
+                    if hatchEggViewModel.animationState.isDismissAllowed {
                         appCoordinator.dismissFullScreenCover()
                     }
                 }
@@ -153,6 +153,9 @@ extension HatchEggView {
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
             hatchEggViewModel.action(.willShowGlowEffect)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+            hatchEggViewModel.action(.allowDismiss)
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
@@ -30,11 +30,14 @@ struct HatchEggView: View {
                     WalkieLottieView(
                         lottie: WalkieLottie.confetti,
                         isPlaying: hatchEggViewModel.animationState.isPlayingConfetti
-                    ).frame(width: screenHeight * 0.54, height: screenHeight * 0.54)
+                    )
+                    .frame(width: screenHeight * 0.54, height: screenHeight * 0.54)
+                    .allowsHitTesting(false)
                 }
                 Image(.glowEffect)
                     .resizable()
                     .frame(width: screenHeight * 0.5, height: screenHeight * 0.5)
+                    .allowsHitTesting(false)
                     .opacity(hatchEggViewModel.animationState.isShowingGlowEffect ? 1 : 0)
                     .animation(.easeInOut(duration: 0.2), value: hatchEggViewModel.animationState.isShowingGlowEffect)
                 
@@ -68,6 +71,7 @@ struct HatchEggView: View {
                     lottie: eggLottie,
                     isPlaying: hatchEggViewModel.animationState.isPlayingEggLottie
                 )
+                .allowsHitTesting(false)
                 .frame(width: screenHeight * 0.27, height: screenHeight * 0.27)
                 .opacity(hatchEggViewModel.animationState.isShowingEggLottie ? 1 : 0)
                 .animation(.easeIn(duration: 0.3), value: !hatchEggViewModel.animationState.isShowingEggLottie)
@@ -88,6 +92,7 @@ struct HatchEggView: View {
                             value: hatchEggViewModel.animationState.isShowingEggHatchText
                         )
                 }
+                .allowsHitTesting(false)
                 .alignmentGuide(VerticalAlignment.center) { view in
                     view[.bottom] + 132
                 }
@@ -109,6 +114,7 @@ struct HatchEggView: View {
                         .font(.B2)
                         .foregroundStyle(WalkieCommonAsset.gray300.swiftUIColor)
                 }
+                .allowsHitTesting(false)
                 .opacity(hatchEggViewModel.animationState.isShowingCharacter ? 1 : 0)
                 .animation(.easeIn(duration: 0.3), value: hatchEggViewModel.animationState.isShowingCharacter)
                 .alignmentGuide(VerticalAlignment.center) { view in

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggView.swift
@@ -154,7 +154,7 @@ extension HatchEggView {
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
             hatchEggViewModel.action(.willShowGlowEffect)
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) {
             hatchEggViewModel.action(.allowDismiss)
         }
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/HatchEgg/HatchEggViewModel.swift
@@ -26,6 +26,7 @@ final class HatchEggViewModel: ViewModelable {
         case willShowConfettiEffectWithVibration // 3.7초
         case willShowcharacter // 3.9초
         case willShowGlowEffect // 4초
+        case allowDismiss // 5초
     }
     
     enum State {
@@ -49,6 +50,7 @@ final class HatchEggViewModel: ViewModelable {
         let isPlayingConfetti: Bool
         let isShowingCharacter: Bool
         let isShowingGlowEffect: Bool
+        let isDismissAllowed: Bool
     }
     
     @Published var state: State = .loading
@@ -60,7 +62,8 @@ final class HatchEggViewModel: ViewModelable {
         isPlayingEggLottie: false,
         isPlayingConfetti: false,
         isShowingCharacter: false,
-        isShowingGlowEffect: false
+        isShowingGlowEffect: false,
+        isDismissAllowed: false
     )
     
     init(
@@ -83,7 +86,8 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: false,
                 isPlayingConfetti: false,
                 isShowingCharacter: false,
-                isShowingGlowEffect: false
+                isShowingGlowEffect: false,
+                isDismissAllowed: false
             )
         case .willShowEggHatchText:
             self.animationState = .init(
@@ -93,7 +97,8 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: false,
                 isPlayingConfetti: false,
                 isShowingCharacter: false,
-                isShowingGlowEffect: false
+                isShowingGlowEffect: false,
+                isDismissAllowed: false
             )
         case .willShowEggLottie:
             self.animationState = .init(
@@ -103,7 +108,8 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: false,
                 isPlayingConfetti: false,
                 isShowingCharacter: false,
-                isShowingGlowEffect: false
+                isShowingGlowEffect: false,
+                isDismissAllowed: false
             )
         case .willPlayEggLottie:
             self.animationState = .init(
@@ -113,7 +119,8 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: true,
                 isPlayingConfetti: false,
                 isShowingCharacter: false,
-                isShowingGlowEffect: false
+                isShowingGlowEffect: false,
+                isDismissAllowed: false
             )
         case .willShowConfettiEffectWithVibration:
             self.animationState = .init(
@@ -123,7 +130,8 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: false,
                 isPlayingConfetti: true,
                 isShowingCharacter: false,
-                isShowingGlowEffect: false
+                isShowingGlowEffect: false,
+                isDismissAllowed: false
             )
         case .willShowcharacter:
             self.animationState = .init(
@@ -133,7 +141,8 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: false,
                 isPlayingConfetti: true,
                 isShowingCharacter: true,
-                isShowingGlowEffect: false
+                isShowingGlowEffect: false,
+                isDismissAllowed: false
             )
         case .willShowGlowEffect:
             self.animationState = .init(
@@ -143,7 +152,19 @@ final class HatchEggViewModel: ViewModelable {
                 isPlayingEggLottie: false,
                 isPlayingConfetti: true,
                 isShowingCharacter: true,
-                isShowingGlowEffect: true
+                isShowingGlowEffect: true,
+                isDismissAllowed: false
+            )
+        case .allowDismiss:
+            self.animationState = .init(
+                isShowingWaitText: false,
+                isShowingEggHatchText: false,
+                isShowingEggLottie: false,
+                isPlayingEggLottie: false,
+                isPlayingConfetti: true,
+                isShowingCharacter: true,
+                isShowingGlowEffect: true,
+                isDismissAllowed: true
             )
         }
     }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Enums/MypageItemEnum.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Enums/MypageItemEnum.swift
@@ -28,7 +28,7 @@ enum MypageItem {
 }
 
 enum MypageSettingSectionItem: MypageSectionItem {
-    case myInfo(isPublic: Bool)
+    case myInfo(isPublic: Bool, nickname: String)
     case pushNotification(notifyEggHatches: Bool)
     
     var title: String {

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainSettingSectionView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/Main/View/MypageMainSettingSectionView.swift
@@ -15,7 +15,10 @@ struct MypageMainSettingSectionView: View {
         if case let .loaded(state) = viewModel.state {
             MypageMainSectionView(title: MypageItem.setting.title) {
                 ForEach([
-                    MypageSettingSectionItem.myInfo(isPublic: state.isPublic),
+                    MypageSettingSectionItem.myInfo(
+                        isPublic: state.isPublic,
+                        nickname: state.nickname
+                    ),
                     MypageSettingSectionItem.pushNotification(
                         notifyEggHatches: NotificationManager.shared.getNotificationMode()
                     )

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageChangeNicknameView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageChangeNicknameView.swift
@@ -20,6 +20,7 @@ struct MypageChangeNicknameView: View {
         VStack(alignment: .leading) {
             NavigationBar(
                 rightButtonTitle: "완료",
+                showBackButton: true,
                 showRightButton: true,
                 rightButtonEnabled: isButtonEnabled,
                 rightButtonShowsEnabledColor: true,

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageChangeNicknameView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageChangeNicknameView.swift
@@ -1,0 +1,68 @@
+//
+//  MypageChangeNicknameView.swift
+//  Walkie-iOS
+//
+//  Created by 황채웅 on 7/25/25.
+//
+
+import SwiftUI
+import WalkieCommon
+
+struct MypageChangeNicknameView: View {
+    
+    @State private var userInput: String = ""
+    @State private var isButtonEnabled: Bool = false
+    @State private var inputState: InputState = .default
+    @FocusState private var focused: Bool
+    @ObservedObject var viewModel: MypageMyInformationViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            NavigationBar(
+                rightButtonTitle: "완료",
+                showRightButton: true,
+                rightButtonEnabled: isButtonEnabled,
+                rightButtonShowsEnabledColor: true,
+                rightButtonAction: {
+                    viewModel.action(.willChangeNickname(userInput))
+                }
+            )
+            
+            Text("새로운 닉네임을\n입력해주세요")
+                .font(.H2)
+                .foregroundColor(WalkieCommonAsset.gray700.swiftUIColor)
+                .padding(.top, 24)
+                .padding(.leading, 16)
+            
+            InputView(
+                limitation: 10,
+                placeholderText: viewModel.state.nickname,
+                onlyText: true,
+                input: $userInput,
+                inputState: $inputState
+            )
+            .focused($focused)
+            .padding(.top, 38)
+            .padding(.horizontal, 16)
+            .onChange(of: inputState) { _, newState in
+                isButtonEnabled = newState == .focus
+            }
+            
+            Spacer()
+        }
+        .alignTo(.leading)
+        .toolbar(.hidden, for: .navigationBar)
+        .contentShape(Rectangle())
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.focused = true
+            }
+        }
+        .onTapGesture {
+            hideKeyboard()
+        }
+        .gesture(DragGesture().onChanged { _ in
+            hideKeyboard()
+        })
+    }
+}

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-
 import WalkieCommon
 
 struct MypageMyInformationView: View {
@@ -23,10 +22,17 @@ struct MypageMyInformationView: View {
             VStack(
                 alignment: .leading,
                 spacing: 0) {
-                    Text("프로필 공개 설정")
+                    Text("프로필 설정")
                         .font(.H4)
                         .foregroundStyle(WalkieCommonAsset.gray700.swiftUIColor)
                         .padding(.bottom, 12)
+                    ChangeNicknameItemView(
+                        nickname: viewModel.state.nickname,
+                        onTap: {
+                            viewModel.action(.didTapChangeNicknameButton)
+                        }
+                    )
+                    .padding(.bottom, 8)
                     SwitchOptionItemView(
                         title: "프로필 공개",
                         subtitle: "내 후기가 다른 사람에게 공개돼요",
@@ -36,6 +42,40 @@ struct MypageMyInformationView: View {
                 }
                 .padding(.top, 12)
                 .padding(.horizontal, 16)
+        }
+    }
+}
+
+private struct ChangeNicknameItemView: View {
+    
+    let nickname: String
+    let onTap: () -> Void
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                Text("닉네임 변경")
+                    .font(.H6)
+                    .foregroundStyle(WalkieCommonAsset.gray700.swiftUIColor)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Spacer(minLength: 0)
+                Text(nickname)
+                    .font(.C1)
+                    .foregroundStyle(WalkieCommonAsset.gray500.swiftUIColor)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            Spacer(minLength: 0)
+            Image(.icChevronRight)
+                .resizable()
+                .frame(width: 24, height: 24)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+        .background(WalkieCommonAsset.gray50.swiftUIColor)
+        .clipShape(.rect(cornerRadius: 12))
+        .onTapGesture {
+            onTap()
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationViewModel.swift
@@ -11,11 +11,13 @@ final class MypageMyInformationViewModel: ViewModelable {
     
     struct State {
         var isPublic: Bool
+        var nickname: String
     }
     
     enum Action {
         case togglePublicSetting
         case didTapBackButton
+        case didTapChangeNicknameButton
     }
     
     private let appCoordinator: AppCoordinator
@@ -24,10 +26,18 @@ final class MypageMyInformationViewModel: ViewModelable {
     
     @Published var state: State
     
-    init(appCoordinator: AppCoordinator, patchProfileUseCase: PatchProfileUseCase, isPublic: Bool) {
+    init(
+        appCoordinator: AppCoordinator,
+        patchProfileUseCase: PatchProfileUseCase,
+        isPublic: Bool,
+        nickname: String
+    ) {
         self.appCoordinator = appCoordinator
         self.patchProfileUseCase = patchProfileUseCase
-        self.state = State(isPublic: isPublic)
+        self.state = State(
+            isPublic: isPublic,
+            nickname: nickname
+        )
     }
     
     func action(_ action: Action) {
@@ -36,6 +46,8 @@ final class MypageMyInformationViewModel: ViewModelable {
             self.togglePublicSetting()
         case .didTapBackButton:
             self.appCoordinator.pop()
+        case .didTapChangeNicknameButton:
+            self.appCoordinator.push(AppScene.nickname)
         }
     }
     
@@ -43,7 +55,10 @@ final class MypageMyInformationViewModel: ViewModelable {
         patchProfileUseCase.patchProfileVisibility().walkieSink(
             with: self,
             receiveValue: { _, _ in
-                self.state = .init(isPublic: !self.state.isPublic)
+                self.state = .init(
+                    isPublic: !self.state.isPublic,
+                    nickname: self.state.nickname
+                )
             }, receiveFailure: { _, error in
                 dump(#function)
                 dump(error)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationViewModel.swift
@@ -71,7 +71,20 @@ final class MypageMyInformationViewModel: ViewModelable {
     }
     
     private func changeNickname(to nickname: String) {
-        // TODO: API 구현 및 연결
-        UserManager.shared.setUserNickname(nickname)
+        patchProfileUseCase.patchProfileNickname(nickname: nickname).walkieSink(
+            with: self,
+            receiveValue: { _, _ in
+                self.state = .init(
+                    isPublic: self.state.isPublic,
+                    nickname: nickname
+                )
+                UserManager.shared.setUserNickname(nickname)
+                self.appCoordinator.pop()
+            }, receiveFailure: { _, error in
+                dump(#function)
+                dump(error)
+                return
+            }
+        ).store(in: &cancellables)
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationViewModel.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Mypage/MyInformation/MypageMyInformationViewModel.swift
@@ -18,6 +18,7 @@ final class MypageMyInformationViewModel: ViewModelable {
         case togglePublicSetting
         case didTapBackButton
         case didTapChangeNicknameButton
+        case willChangeNickname(String)
     }
     
     private let appCoordinator: AppCoordinator
@@ -47,11 +48,13 @@ final class MypageMyInformationViewModel: ViewModelable {
         case .didTapBackButton:
             self.appCoordinator.pop()
         case .didTapChangeNicknameButton:
-            self.appCoordinator.push(AppScene.nickname)
+            self.appCoordinator.push(AppScene.changeNickname(viewModel: self))
+        case let .willChangeNickname(nickname):
+            self.changeNickname(to: nickname)
         }
     }
     
-    func togglePublicSetting() {
+    private func togglePublicSetting() {
         patchProfileUseCase.patchProfileVisibility().walkieSink(
             with: self,
             receiveValue: { _, _ in
@@ -65,5 +68,10 @@ final class MypageMyInformationViewModel: ViewModelable {
                 return
             }
         ).store(in: &cancellables)
+    }
+    
+    private func changeNickname(to nickname: String) {
+        // TODO: API 구현 및 연결
+        UserManager.shared.setUserNickname(nickname)
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Route/AppScene.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 enum AppScene: AppRoute {
     
-    case splash, nickname, complete, login, tabBar
+    case splash, nickname, complete, login, tabBar, changeNickname(viewModel: MypageMyInformationViewModel)
     case healthcare
     case map
     case egg, eggGuide, character, review


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

### 닉네임 변경 Domain/Presentation Layer 구현
- 기존에 닉네임 변경 유즈케이스 구현되어있어서 그대로 연결했습니다
- post로 잘못 매핑되어있어서 patch로 변경하였습니다
- 기존 `NicknameView`에서 레이아웃 가져왔고, 닉네임 변경 뷰에 맞게 약간 수정했습니다
- 뷰모델은 `MypageMyInfoViewModel` 같이 사용했습니다

### 알 부화 dimView 터치 레이아웃 수정
- 디자인팀 수정 요청 반영하여 6초부터 dimView 영역 터치하여 dismiss 가능하도록 했습니다!
- dimView 영역이 글자 영역과 confetti 로티에 가려져 있었던 걸 수정했습니다!
- 이젠 캐릭터 이미지 영역 제외 dimView 영역은 모두 터치하여 dismiss 가능합니다

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->

📸 **스크린샷**

**[닉네임 수정 기능, 네비바 백버튼 테스트]**

https://github.com/user-attachments/assets/e7b83c73-a517-4da4-aa15-86ca178ea133

**[알 부화 뷰 6초 이후 dismiss / dimView 레이아웃 테스트]**

https://github.com/user-attachments/assets/225c0a17-79dd-42e2-b14e-cff5b19b5a24


📟 **관련 이슈**
- Resolved: #205 , #206 
