### PR TITLE
[Fix] #210 - 홈화면 이벤트 체크 로직 수정 및 헬스케어뷰 문구 변경

### DIFF
--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -42,6 +42,7 @@ final class AppCoordinator: Coordinator, ObservableObject {
     var permissionFlow: PermissionFlowCoordinator?
     var eventFlow: EventFlowCoordinator?
     private var cancellables: Set<AnyCancellable> = []
+    var selectedTab: TabBarItem = .home
     
     init(
         diContainer: DIContainer
@@ -466,6 +467,11 @@ extension AppCoordinator {
     }
     
     private func showEventEggAlert() {
+        guard
+            currentScene == .tabBar,
+            selectedTab == .home
+        else { return }
+        
         eventFlow?.checkEvent { [weak self] in
             guard
                 let self = self,

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/EventFlowCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/EventFlowCoordinator.swift
@@ -24,6 +24,10 @@ final class EventFlowCoordinator: ObservableObject {
         self.remoteConfigManager = remoteConfigManager
         self.getEventEggUseCase  = getEventEggUseCase
     }
+    
+    func clearEventEntity() {
+        self.eventEggEntity = nil
+    }
 
     func checkEvent(completion: (() -> Void)? = nil) {
         Task {
@@ -51,8 +55,10 @@ final class EventFlowCoordinator: ObservableObject {
                     .walkieSink(
                         with: self,
                         receiveValue: { _, entity in
-                            self.eventEggEntity = entity.canReceive ? entity : nil
-                            UserManager.shared.setLastVisitedDate(now)
+                            self.eventEggEntity = entity
+                            if entity.canReceive {
+                                UserManager.shared.setLastVisitedDate(now)
+                            }
                             completion?()
                         },
                         receiveFailure: { _, _ in

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/StepCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/StepCoordinator.swift
@@ -17,7 +17,7 @@ final class StepCoordinator {
     // MARK: - Publishers
     private let hatchSubject = PassthroughSubject<Bool, Error>()
     var hatchPublisher: AnyPublisher<Bool, Error> {
-        hatchSubject.share().eraseToAnyPublisher()
+        hatchSubject.eraseToAnyPublisher()
     }
     
     // MARK: - UseCases
@@ -62,6 +62,8 @@ final class StepCoordinator {
     
     func startStepQuery(onUpdate: @escaping () -> Void) {
         updateStepForegroundUseCase.start()
+            .map { _ in () }
+            .prepend(()) 
             .receive(on: DispatchQueue.main)
             .sink(
                 receiveCompletion: { completion in

--- a/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/StepCoordinator.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/App/Coordinator/CoordinatorImpl/StepCoordinator.swift
@@ -105,6 +105,7 @@ final class StepCoordinator {
                     }
                 }
             case .failure:
+                self.hatchSubject.send(false)
                 stopStepUpdates()
             }
         }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Common/TabBar/TabBarView.swift
@@ -91,6 +91,10 @@ struct TabBarView: View {
         }
         .onAppear {
             appCoordinator.executeForegroundActions()
+            appCoordinator.selectedTab = selectedTab
+        }
+        .onChange(of: selectedTab) { _, newTab in
+            appCoordinator.selectedTab = newTab
         }
     }
 }

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/HealthCare/CalendarView/HealthCareWeekScrollView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/HealthCare/CalendarView/HealthCareWeekScrollView.swift
@@ -16,7 +16,7 @@ struct HealthCareWeekScrollView: View {
     
     // 헬스케어 관련
     let selectedDate: Date
-    let healthCareData: [Date : (nowStep: Int, targetStep: Int)]
+    let healthCareData: [Date: (nowStep: Int, targetStep: Int)]
     
     // 선택 시
     let onTap: (Date) -> Void

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/HealthCare/View/HelathCareInfoView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/HealthCare/View/HelathCareInfoView.swift
@@ -54,7 +54,7 @@ struct HealthCareInfoView: View {
                     }
                 }
                 
-                Text("오늘의 걸음")
+                Text("일일 걸음수")
                     .font(.H5)
                     .foregroundColor(WalkieCommonAsset.gray700.swiftUIColor)
                     .alignTo(.leading)

--- a/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/HealthCare/View/Skeleton/HealthCareInfoSkeletonView.swift
+++ b/Walkie-iOS/Walkie-iOS/Sources/Presentation/Main/HealthCare/View/Skeleton/HealthCareInfoSkeletonView.swift
@@ -42,7 +42,7 @@ struct HealthCareInfoSkeletonView: View {
                         .foregroundColor(WalkieCommonAsset.gray100.swiftUIColor)
                 }
                 
-                Text("오늘의 걸음")
+                Text("일일 걸음수")
                     .font(.H5)
                     .foregroundColor(WalkieCommonAsset.gray700.swiftUIColor)
                     .alignTo(.leading)


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
### 홈화면 이벤트 체크 로직 수정
- 이벤트 알럿이 홈에 들어올때마다 여러번 계속 뜨는 이슈: `eventFlow` 구독시점의 문제로 `eventEggEntity` 값이 초기화되지 않고 계속 남아있어서 값이 방출되었기 때문
- 또한 홈이 아닌 이외의 곳에서 알이 부화된 이후에도 이벤트 여부가 체크되면서 다른 화면에서도 이벤트 알럿이 뜨는 가능성이 있을 수 있을거 같아서 `currentScene`과 `selectedTab`을 사용해서 분기처리 해주었습니다!
```swift
 private func showEventEggAlert() {
        guard
            currentScene == .tabBar,
            selectedTab == .home
        else { return }
        
        eventFlow?.checkEvent { [weak self] in
            guard
                let self = self,
                let entity = self.eventFlow?.eventEggEntity,
                entity.canReceive
            else { return }
            
            buildEventAlert( /* 생략 */)
        }
    }
```
- 부화중인 알이 없을때 이벤트가 안뜨던 이슈: `StepCoordinator`에서 알이 없을때는 `failure`로 넘어오는데 그때는 `hatchSubject` 방출을 하고 있지 않았기 때문 → 해당 상황에서도 `false` 방출
```swift
fetchEggPlay { [weak self] result in
            guard let self else { return }
            switch result {
            case .success(let egg): // 생략
            case .failure:
                self.hatchSubject.send(false)
                stopStepUpdates()
            }
```
- 홈에 들어와도 걸은 걸음수 업데이트할게 없을 때 이벤트 알럿이 안뜨는 이슈: 업데이트할 값이 없어서 방출되는 것도 없었기 때문 → 구독 직후에 초기 이벤트 발생하도록 추가
```swift
hatchSubject.eraseToAnyPublisher() // 불필요한 멀티캐스트 로직 제거

updateStepForegroundUseCase.start()
    .map { _ in () }
    .prepend(()) 
```

###  헬스케어뷰, 스켈레톤 타이틀 문구 수정
- 오늘의 걸음 → 일일 걸음수로 문구 수정

📸 **스크린샷**
|기능|스크린샷|스크린샷|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/fd7549b7-6566-42e0-aa07-b3243ecdcdd4" width ="250">|<img src = "https://github.com/user-attachments/assets/f1f6010f-6e45-4cd6-8fe2-cc68f9db8b2d" width ="250">|

📟 **관련 이슈**
- Resolved: #210 
