### PR TITLE
[Hotfix] #244 - iOS 26 리퀴드글래스 임시 조치

### DIFF
--- a/Walkie-iOS/Project.swift
+++ b/Walkie-iOS/Project.swift
@@ -88,7 +88,8 @@ let project = Project(
                         "fetch",
                         "processing",
                         "location"
-                    ]
+                    ],
+                    "UIDesignRequiresCompatibility": true
                 ]
             ),
             sources: ["Walkie-iOS/Sources/**"],


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
UIDesignRequiresCompatibility 값 true로 설정하여 iOS 26 신규 UI를 적용하지 않도록 설정하였습니다

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. -->
1. iOS에 LaunchServices의 캐시가 bundle identifier 기준으로 Info.plist 정보를 저장하고 있다고합니다.
(롤백 시 UIDesignRequiresCompatibility 항목 삭제가 아니라 값을 false로 명시적 변경해줘야합니다)
2. 최소버전 설정이 안 되어 있어서 해야될 것 같은데, 몇으로 하는 게 좋을까요?

📸 **스크린샷**

|조치 전|조치 후|
|:--:|:--:|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/1cfd0455-91bb-46d0-a932-5c98da1da083" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fb7d15d8-701b-4d36-806a-731e946d59ab" /> |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/27fd09ed-31d8-4151-94ef-f25c99166e2d" />  | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/55f0baea-6237-429e-9fe5-f6029d00f70d" /> |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/13ff2310-9998-49de-9f23-8f385442e508" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9e4e4e8c-b69d-464b-b98d-58d4cceaf80f" /> |



📟 **관련 이슈**
- Resolved: #244 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **작업**
  * 앱 디자인 호환성 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->